### PR TITLE
feat: add problems module

### DIFF
--- a/docs/problems.md
+++ b/docs/problems.md
@@ -1,0 +1,50 @@
+# Problems Module
+
+Provides CRUD-style APIs for LeetCode problems metadata. Used by sync, scheduling and lists.
+
+## Endpoints
+
+### `GET /problems`
+Query params: `search`, `tag`, `difficulty`, `limit` (default 20, max 100), `offset` (default 0)
+
+Returns: `{ items: Problem[], total: number, limit: number, offset: number }`
+
+### `GET /problems/:slug`
+Fetch a problem by slug. Returns 404 if not found.
+
+### `PUT /problems/:slug`
+Upsert a problem. Body: `UpsertProblemDto`. Slug in URL must match body.
+
+### `POST /problems/import`
+Bulk import problems. Body: `BulkImportProblemsDto`. Returns `{ created, updated, errors[] }`.
+
+## DTOs
+
+`UpsertProblemDto`
+```ts
+{
+  slug: string;
+  title: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  tags?: string[]; // defaults to []
+  description?: string;
+}
+```
+
+`GetProblemsQueryDto`
+```ts
+{
+  search?: string;
+  tag?: string;
+  difficulty?: 'Easy' | 'Medium' | 'Hard';
+  limit?: number; // default 20, max 100
+  offset?: number; // default 0
+}
+```
+
+`BulkImportProblemsDto`
+```ts
+{
+  items: UpsertProblemDto[];
+}
+```

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
@@ -54,6 +56,7 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
+    "sqlite3": "^5.1.7",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ProblemsModule } from './problems/problems.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AppService } from './app.service';
       autoLoadEntities: true,
       synchronize: false,
     }),
+    ProblemsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/problems/dto/bulk-import-problems.dto.ts
+++ b/src/problems/dto/bulk-import-problems.dto.ts
@@ -1,0 +1,10 @@
+import { Type } from 'class-transformer';
+import { IsArray, ValidateNested } from 'class-validator';
+import { UpsertProblemDto } from './upsert-problem.dto';
+
+export class BulkImportProblemsDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpsertProblemDto)
+  items: UpsertProblemDto[];
+}

--- a/src/problems/dto/get-problems-query.dto.ts
+++ b/src/problems/dto/get-problems-query.dto.ts
@@ -1,0 +1,29 @@
+import { IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetProblemsQueryDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsString()
+  tag?: string;
+
+  @IsOptional()
+  @IsIn(['Easy', 'Medium', 'Hard'])
+  difficulty?: 'Easy' | 'Medium' | 'Hard';
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset: number = 0;
+}

--- a/src/problems/dto/upsert-problem.dto.ts
+++ b/src/problems/dto/upsert-problem.dto.ts
@@ -1,0 +1,30 @@
+import { Transform } from 'class-transformer';
+import {
+  IsArray,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class UpsertProblemDto {
+  @IsNotEmpty()
+  @IsString()
+  slug: string;
+
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @IsIn(['Easy', 'Medium', 'Hard'])
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+
+  @Transform(({ value }) => value ?? [])
+  @IsArray()
+  @IsString({ each: true })
+  tags: string[] = [];
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/src/problems/problems.controller.spec.ts
+++ b/src/problems/problems.controller.spec.ts
@@ -1,0 +1,109 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import request from 'supertest';
+import { Problem } from './problem.entity';
+import { ProblemsModule } from './problems.module';
+import { ProblemsService } from './problems.service';
+
+describe('ProblemsController', () => {
+  let app: INestApplication;
+  let service: ProblemsService;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          dropSchema: true,
+          entities: [Problem],
+          synchronize: true,
+        }),
+        ProblemsModule,
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ transform: true, whitelist: true }),
+    );
+    await app.init();
+    service = moduleRef.get(ProblemsService);
+
+    await service.createOrUpdateFromLcMeta({
+      slug: 'two-sum',
+      title: 'Two Sum',
+      difficulty: 'Easy',
+      tags: ['Array', 'Hash Table'],
+    });
+    await service.createOrUpdateFromLcMeta({
+      slug: 'three-sum',
+      title: '3Sum',
+      difficulty: 'Medium',
+      tags: ['Array', 'Two Pointers'],
+    });
+    await service.createOrUpdateFromLcMeta({
+      slug: 'binary-search',
+      title: 'Binary Search',
+      difficulty: 'Easy',
+      tags: ['Binary Search'],
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /problems returns paginated list', async () => {
+    const res = await request(app.getHttpServer()).get(
+      '/problems?limit=2&offset=0',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.items.length).toBe(2);
+    expect(res.body.total).toBe(3);
+    expect(res.body.limit).toBe(2);
+    expect(res.body.offset).toBe(0);
+  });
+
+  it('filters by difficulty, tag and search', async () => {
+    const res = await request(app.getHttpServer()).get(
+      '/problems?difficulty=Medium&tag=array&search=sum',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.items.length).toBe(1);
+    expect(res.body.items[0].slug).toBe('three-sum');
+  });
+
+  it('GET /problems/:slug returns 404 when missing', async () => {
+    const res = await request(app.getHttpServer()).get(
+      '/problems/not-found',
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /problems/import returns created/updated counts', async () => {
+    const payload = {
+      items: [
+        {
+          slug: 'two-sum',
+          title: 'Two Sum',
+          difficulty: 'Easy',
+          tags: ['Array'],
+        },
+        {
+          slug: 'four-sum',
+          title: '4Sum',
+          difficulty: 'Hard',
+          tags: ['Array'],
+        },
+      ],
+    };
+    const res = await request(app.getHttpServer())
+      .post('/problems/import')
+      .send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.created).toBe(1);
+    expect(res.body.updated).toBe(1);
+  });
+});

--- a/src/problems/problems.controller.ts
+++ b/src/problems/problems.controller.ts
@@ -1,0 +1,53 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+  NotFoundException,
+} from '@nestjs/common';
+import { ProblemsService } from './problems.service';
+import { GetProblemsQueryDto } from './dto/get-problems-query.dto';
+import { UpsertProblemDto } from './dto/upsert-problem.dto';
+import { BulkImportProblemsDto } from './dto/bulk-import-problems.dto';
+
+@Controller('problems')
+export class ProblemsController {
+  constructor(private readonly problemsService: ProblemsService) {}
+
+  @Get()
+  async getProblems(@Query() query: GetProblemsQueryDto) {
+    return this.problemsService.findAll(query);
+  }
+
+  @Get(':slug')
+  async getBySlug(@Param('slug') slug: string) {
+    const problem = await this.problemsService.findBySlug(slug);
+    if (!problem) {
+      throw new NotFoundException('Problem not found');
+    }
+    return problem;
+  }
+
+  @Post('import')
+  @HttpCode(HttpStatus.OK)
+  async bulkImport(@Body() body: BulkImportProblemsDto) {
+    return this.problemsService.bulkImportFromJson(body.items);
+  }
+
+  @Put(':slug')
+  async upsertProblem(
+    @Param('slug') slug: string,
+    @Body() dto: UpsertProblemDto,
+  ) {
+    if (slug !== dto.slug) {
+      throw new BadRequestException('Slug mismatch');
+    }
+    return this.problemsService.createOrUpdateFromLcMeta(dto);
+  }
+}

--- a/src/problems/problems.module.ts
+++ b/src/problems/problems.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Problem } from './problem.entity';
+import { ProblemsService } from './problems.service';
+import { ProblemsController } from './problems.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Problem])],
+  providers: [ProblemsService],
+  controllers: [ProblemsController],
+  exports: [ProblemsService, TypeOrmModule],
+})
+export class ProblemsModule {}

--- a/src/problems/problems.service.spec.ts
+++ b/src/problems/problems.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProblemsService } from './problems.service';
+import { Problem } from './problem.entity';
+import { UpsertProblemDto } from './dto/upsert-problem.dto';
+
+describe('ProblemsService', () => {
+  let service: ProblemsService;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          dropSchema: true,
+          entities: [Problem],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([Problem]),
+      ],
+      providers: [ProblemsService],
+    }).compile();
+
+    service = module.get(ProblemsService);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  it('upsert creates when not exists', async () => {
+    await service.createOrUpdateFromLcMeta({
+      slug: 'two-sum',
+      title: 'Two Sum',
+      difficulty: 'Easy',
+      tags: ['Array', 'Hash Table'],
+    });
+    const problem = await service.findBySlug('two-sum');
+    expect(problem).toBeTruthy();
+    expect(problem?.title).toBe('Two Sum');
+    expect(problem?.tags).toEqual(['array', 'hash table']);
+  });
+
+  it('upsert updates existing problem', async () => {
+    await service.createOrUpdateFromLcMeta({
+      slug: 'two-sum',
+      title: 'Two Sum Updated',
+      difficulty: 'Medium',
+      tags: ['Array'],
+      description: 'desc',
+    });
+    const problem = await service.findBySlug('two-sum');
+    expect(problem?.title).toBe('Two Sum Updated');
+    expect(problem?.difficulty).toBe('Medium');
+    expect(problem?.tags).toEqual(['array']);
+    expect(problem?.description).toBe('desc');
+  });
+
+  it('bulk import counts created and updated', async () => {
+    const res = await service.bulkImportFromJson([
+      {
+        slug: 'two-sum',
+        title: 'Two Sum Again',
+        difficulty: 'Easy',
+        tags: ['Array'],
+      },
+      {
+        slug: 'three-sum',
+        title: '3Sum',
+        difficulty: 'Medium',
+        tags: ['Array'],
+      },
+    ] as UpsertProblemDto[]);
+    expect(res.created).toBe(1);
+    expect(res.updated).toBe(1);
+    const all = await service.findAll();
+    expect(all.total).toBe(2);
+  });
+
+  it('normalizes tags (trim, dedupe, lowercase)', async () => {
+    await service.createOrUpdateFromLcMeta({
+      slug: 'normalize',
+      title: 'Normalize',
+      difficulty: 'Hard',
+      tags: [' Array ', 'array', 'HASH Table', 'hash table '],
+    });
+    const problem = await service.findBySlug('normalize');
+    expect(problem?.tags).toEqual(['array', 'hash table']);
+  });
+});

--- a/src/problems/problems.service.ts
+++ b/src/problems/problems.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Problem } from './problem.entity';
+import { GetProblemsQueryDto } from './dto/get-problems-query.dto';
+import { UpsertProblemDto } from './dto/upsert-problem.dto';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+@Injectable()
+export class ProblemsService {
+  constructor(
+    @InjectRepository(Problem)
+    private readonly repo: Repository<Problem>,
+  ) {}
+
+  async findAll(query: GetProblemsQueryDto = {} as any) {
+    const qb = this.repo.createQueryBuilder('problem');
+
+    if (query.search) {
+      qb.andWhere(
+        '(LOWER(problem.title) LIKE :search OR LOWER(problem.slug) LIKE :search)',
+        { search: `%${query.search.toLowerCase()}%` },
+      );
+    }
+    if (query.difficulty) {
+      qb.andWhere('problem.difficulty = :difficulty', {
+        difficulty: query.difficulty,
+      });
+    }
+    if (query.tag) {
+      qb.andWhere('LOWER(problem.tags) LIKE :tag', {
+        tag: `%${query.tag.toLowerCase()}%`,
+      });
+    }
+
+    const limit = Math.min(query.limit ?? 20, 100);
+    const offset = query.offset ?? 0;
+    qb.take(limit).skip(offset);
+
+    const [items, total] = await qb.getManyAndCount();
+    return { items, total, limit, offset };
+  }
+
+  async findBySlug(slug: string): Promise<Problem | null> {
+    return this.repo.findOne({ where: { slug } });
+  }
+
+  private normalizeTags(tags: string[] = []): string[] {
+    const normalized = tags
+      .map((t) => t.trim().toLowerCase())
+      .filter((t) => t.length > 0);
+    return Array.from(new Set(normalized));
+  }
+
+  async createOrUpdateFromLcMeta(
+    meta: UpsertProblemDto,
+    repository: Repository<Problem> = this.repo,
+  ): Promise<Problem> {
+    const normalizedTags = this.normalizeTags(meta.tags || []);
+    let problem = await repository.findOne({ where: { slug: meta.slug } });
+    if (!problem) {
+      problem = repository.create({ slug: meta.slug });
+    }
+    problem.title = meta.title;
+    problem.difficulty = meta.difficulty;
+    problem.tags = normalizedTags;
+    problem.description = meta.description;
+    return repository.save(problem);
+  }
+
+  async bulkImportFromJson(items: UpsertProblemDto[]) {
+    let created = 0;
+    let updated = 0;
+    const errors: { index: number; reason: string }[] = [];
+
+    await this.repo.manager.transaction(async (manager) => {
+      const repo = manager.getRepository(Problem);
+      for (let i = 0; i < items.length; i++) {
+        const dto = plainToInstance(UpsertProblemDto, items[i]);
+        const validationErrors = validateSync(dto);
+        if (validationErrors.length) {
+          errors.push({
+            index: i,
+            reason: Object.values(
+              validationErrors[0].constraints ?? {},
+            ).join(', '),
+          });
+          continue;
+        }
+        const exists = await repo.findOne({ where: { slug: dto.slug } });
+        await this.createOrUpdateFromLcMeta(dto, repo);
+        if (exists) {
+          updated++;
+        } else {
+          created++;
+        }
+      }
+    });
+
+    return { created, updated, errors };
+  }
+}


### PR DESCRIPTION
## Summary
- add Problems module with entity repository, service, and controller
- support listing/filtering, fetch by slug, upsert and bulk import
- provide DTOs, docs, and unit/e2e-style tests

## Testing
- `npm test` *(fails: Cannot find module 'class-transformer')*


------
https://chatgpt.com/codex/tasks/task_e_689529e384d8832cbd183a1fea8c9142