### PR TITLE
feat: add LeetCode sync module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,10 @@ DB_NAME=leetcode
 
 # Application port
 PORT=3000
+
+# LeetCode integration
+LC_USERNAME=your_username
+LC_CSRF_TOKEN=xxxxx
+LC_SESSION=xxxxx
+LC_BASE_URL=https://leetcode.com/graphql
+LC_PAGE_SIZE=20

--- a/docs/leetcode-sync.md
+++ b/docs/leetcode-sync.md
@@ -1,0 +1,33 @@
+# LeetCode Sync Module
+
+This module syncs accepted submissions and problem metadata from LeetCode into the local database.
+
+## Obtaining Cookies
+1. Log in to [LeetCode](https://leetcode.com) in your browser.
+2. Inspect cookies and copy values for `LEETCODE_SESSION` and `csrftoken`.
+3. Set the following environment variables in `.env`:
+
+```
+LC_USERNAME=<your username>
+LC_CSRF_TOKEN=<csrftoken>
+LC_SESSION=<LEETCODE_SESSION>
+```
+
+## Triggering Sync
+Use the development endpoint:
+
+```
+POST /leetcode/sync
+{
+  "username": "<optional username>",
+  "limit": 20
+}
+```
+
+The endpoint pulls recent accepted submissions, upserts problems, and stores the latest solution code in `UserProblem`.
+
+## Data Mapping
+- `difficulty` is stored as `Easy`, `Medium`, or `Hard`.
+- Tags are normalized to lowercase.
+- `lastSolutionCode` is updated only for accepted submissions.
+- New `UserProblem` rows start with `interval = 1`, `repetition = 0`, `easinessFactor = 2.5`.

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": ["**/*.graphql"],
+    "watchAssets": true
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UserProblemsModule } from './user-problems/user-problems.module';
 import { ProblemsModule } from './problems/problems.module';
+import { LeetcodeModule } from './leetcode/leetcode.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { ProblemsModule } from './problems/problems.module';
     }),
     UserProblemsModule,
     ProblemsModule,
+    LeetcodeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/leetcode/dto/recent.dto.ts
+++ b/src/leetcode/dto/recent.dto.ts
@@ -1,0 +1,8 @@
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class RecentDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}

--- a/src/leetcode/dto/sync.dto.ts
+++ b/src/leetcode/dto/sync.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class SyncDto {
+  @IsOptional()
+  @IsString()
+  username?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}

--- a/src/leetcode/graphql/questionDetail.graphql
+++ b/src/leetcode/graphql/questionDetail.graphql
@@ -1,0 +1,9 @@
+query getQuestionDetail($titleSlug: String!) {
+  question(titleSlug: $titleSlug) {
+    questionId
+    title
+    difficulty
+    topicTags { name slug }
+    content
+  }
+}

--- a/src/leetcode/graphql/recentAcSubmissions.graphql
+++ b/src/leetcode/graphql/recentAcSubmissions.graphql
@@ -1,0 +1,8 @@
+query recentAcSubmissions($username: String!, $limit: Int!) {
+  recentAcSubmissionList(username: $username, limit: $limit) {
+    id
+    title
+    titleSlug
+    timestamp
+  }
+}

--- a/src/leetcode/graphql/submissionDetail.graphql
+++ b/src/leetcode/graphql/submissionDetail.graphql
@@ -1,0 +1,11 @@
+query submissionDetails($submissionId: ID!) {
+  submissionDetail(submissionId: $submissionId) {
+    id
+    code
+    lang
+    runtime
+    memory
+    statusDisplay
+    timestamp
+  }
+}

--- a/src/leetcode/leetcode.client.ts
+++ b/src/leetcode/leetcode.client.ts
@@ -1,0 +1,38 @@
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { LEETCODE_CONFIG, LeetcodeConfig } from './leetcode.config';
+
+@Injectable()
+export class LeetcodeClient {
+  constructor(
+    @Inject(LEETCODE_CONFIG) private readonly config: LeetcodeConfig,
+  ) {}
+
+  private async request(body: any, retries = 3): Promise<any> {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      const res = await fetch(this.config.baseUrl, {
+        method: 'POST',
+        headers: {
+          Cookie: `LEETCODE_SESSION=${this.config.session}; csrftoken=${this.config.csrfToken}`,
+          'x-csrftoken': this.config.csrfToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      if (res.status === 401 || res.status === 403) {
+        throw new UnauthorizedException('Invalid/expired session cookies');
+      }
+      if (!res.ok && res.status >= 500 && attempt < retries) {
+        await new Promise((r) => setTimeout(r, 2 ** attempt * 100));
+        continue;
+      }
+      if (!res.ok) {
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+      return res.json();
+    }
+  }
+
+  post<T>(query: string, variables: Record<string, any>): Promise<T> {
+    return this.request({ query, variables });
+  }
+}

--- a/src/leetcode/leetcode.client.ts
+++ b/src/leetcode/leetcode.client.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
-import { LEETCODE_CONFIG, LeetcodeConfig } from './leetcode.config';
+import { LEETCODE_CONFIG, type LeetcodeConfig } from './leetcode.config';
 
 @Injectable()
 export class LeetcodeClient {

--- a/src/leetcode/leetcode.config.ts
+++ b/src/leetcode/leetcode.config.ts
@@ -1,0 +1,17 @@
+export interface LeetcodeConfig {
+  username: string;
+  csrfToken: string;
+  session: string;
+  baseUrl: string;
+  pageSize: number;
+}
+
+export const LEETCODE_CONFIG = 'LEETCODE_CONFIG';
+
+export const loadLeetcodeConfig = (): LeetcodeConfig => ({
+  username: process.env.LC_USERNAME ?? '',
+  csrfToken: process.env.LC_CSRF_TOKEN ?? '',
+  session: process.env.LC_SESSION ?? '',
+  baseUrl: process.env.LC_BASE_URL ?? 'https://leetcode.com/graphql',
+  pageSize: parseInt(process.env.LC_PAGE_SIZE ?? '20', 10),
+});

--- a/src/leetcode/leetcode.controller.spec.ts
+++ b/src/leetcode/leetcode.controller.spec.ts
@@ -1,0 +1,31 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeetcodeController } from './leetcode.controller';
+import { LeetcodeService } from './leetcode.service';
+
+describe('LeetcodeController', () => {
+  let controller: LeetcodeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LeetcodeController],
+      providers: [
+        {
+          provide: LeetcodeService,
+          useValue: {
+            getRecentAccepted: jest.fn(),
+            syncRecentAccepted: jest.fn(),
+            getQuestionDetail: jest.fn(),
+            getDefaultUsername: () => 'me',
+            getDefaultPageSize: () => 20,
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<LeetcodeController>(LeetcodeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/leetcode/leetcode.controller.ts
+++ b/src/leetcode/leetcode.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { LeetcodeService } from './leetcode.service';
+import { SyncDto } from './dto/sync.dto';
+import { RecentDto } from './dto/recent.dto';
+
+@Controller('leetcode')
+export class LeetcodeController {
+  constructor(private readonly service: LeetcodeService) {}
+
+  @Post('sync')
+  sync(@Body() dto: SyncDto) {
+    return this.service.syncRecentAccepted(dto);
+  }
+
+  @Get('recent')
+  recent(@Query() query: RecentDto) {
+    return this.service.getRecentAccepted(
+      this.service.getDefaultUsername(),
+      query.limit ?? this.service.getDefaultPageSize(),
+    );
+  }
+
+  @Get('question/:slug')
+  question(@Param('slug') slug: string) {
+    return this.service.getQuestionDetail(slug);
+  }
+}

--- a/src/leetcode/leetcode.module.ts
+++ b/src/leetcode/leetcode.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { LeetcodeService } from './leetcode.service';
+import { LeetcodeController } from './leetcode.controller';
+import { LeetcodeClient } from './leetcode.client';
+import { loadLeetcodeConfig, LEETCODE_CONFIG } from './leetcode.config';
+import { ProblemsModule } from '../problems/problems.module';
+import { UserProblemsModule } from '../user-problems/user-problems.module';
+
+@Module({
+  imports: [ProblemsModule, UserProblemsModule],
+  providers: [
+    LeetcodeService,
+    LeetcodeClient,
+    { provide: LEETCODE_CONFIG, useFactory: loadLeetcodeConfig },
+  ],
+  controllers: [LeetcodeController],
+  exports: [LeetcodeService],
+})
+export class LeetcodeModule {}

--- a/src/leetcode/leetcode.service.spec.ts
+++ b/src/leetcode/leetcode.service.spec.ts
@@ -1,0 +1,109 @@
+import { Test } from '@nestjs/testing';
+import { LeetcodeService } from './leetcode.service';
+import { LeetcodeClient } from './leetcode.client';
+import { ProblemsService } from '../problems/problems.service';
+import { UserProblemsService } from '../user-problems/user-problems.service';
+import { LEETCODE_CONFIG } from './leetcode.config';
+
+describe('LeetcodeService', () => {
+  let service: LeetcodeService;
+  let client: { post: jest.Mock };
+  let problems: { findBySlug: jest.Mock; createOrUpdateFromLcMeta: jest.Mock };
+  let userProblems: { linkProblemToUser: jest.Mock; updateCode: jest.Mock };
+
+  beforeEach(async () => {
+    client = { post: jest.fn() };
+    problems = { findBySlug: jest.fn(), createOrUpdateFromLcMeta: jest.fn() };
+    userProblems = { linkProblemToUser: jest.fn(), updateCode: jest.fn() };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        LeetcodeService,
+        { provide: LeetcodeClient, useValue: client },
+        { provide: ProblemsService, useValue: problems },
+        { provide: UserProblemsService, useValue: userProblems },
+        { provide: LEETCODE_CONFIG, useValue: { username: 'me', pageSize: 20 } },
+      ],
+    }).compile();
+
+    service = module.get(LeetcodeService);
+  });
+
+  it('getRecentAccepted maps fields correctly', async () => {
+    client.post.mockResolvedValue({
+      data: {
+        recentAcSubmissionList: [
+          { id: 1, title: 'Two Sum', titleSlug: 'two-sum', timestamp: '123' },
+        ],
+      },
+    });
+    const result = await service.getRecentAccepted('me', 1);
+    expect(result).toEqual([
+      { id: '1', title: 'Two Sum', titleSlug: 'two-sum', timestamp: 123 },
+    ]);
+  });
+
+  it('syncRecentAccepted upserts and updates code', async () => {
+    client.post
+      .mockResolvedValueOnce({
+        data: {
+          recentAcSubmissionList: [
+            { id: 1, title: 'Two Sum', titleSlug: 'two-sum', timestamp: '1' },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          question: {
+            title: 'Two Sum',
+            difficulty: 'Easy',
+            topicTags: [],
+            content: '',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { submissionDetail: { statusDisplay: 'Accepted', code: 'code' } },
+      });
+    problems.findBySlug.mockResolvedValue(null);
+    problems.createOrUpdateFromLcMeta.mockResolvedValue({ id: 'p1' });
+    userProblems.linkProblemToUser.mockResolvedValue({ id: 'up1', interval: 1, repetition: 0 });
+    userProblems.updateCode.mockResolvedValue({});
+
+    const res = await service.syncRecentAccepted({ username: 'me', limit: 1 });
+    expect(problems.createOrUpdateFromLcMeta).toHaveBeenCalled();
+    expect(userProblems.updateCode).toHaveBeenCalledWith('up1', 'code');
+    expect(res).toEqual({ created: 1, updated: 0, failures: 0, items: ['two-sum'] });
+  });
+
+  it('syncRecentAccepted counts failures', async () => {
+    client.post
+      .mockResolvedValueOnce({
+        data: {
+          recentAcSubmissionList: [
+            { id: 1, title: 'Two Sum', titleSlug: 'two-sum', timestamp: '1' },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          question: {
+            title: 'Two Sum',
+            difficulty: 'Easy',
+            topicTags: [],
+            content: '',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { submissionDetail: { statusDisplay: 'Wrong Answer', code: 'code' } },
+      });
+    problems.findBySlug.mockResolvedValue(null);
+    problems.createOrUpdateFromLcMeta.mockResolvedValue({ id: 'p1' });
+    userProblems.linkProblemToUser.mockResolvedValue({ id: 'up1', interval: 1, repetition: 0 });
+    userProblems.updateCode.mockResolvedValue({});
+
+    const res = await service.syncRecentAccepted({ username: 'me', limit: 1 });
+    expect(res.failures).toBe(1);
+  });
+});

--- a/src/leetcode/leetcode.service.ts
+++ b/src/leetcode/leetcode.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ProblemsService } from '../problems/problems.service';
 import { UserProblemsService } from '../user-problems/user-problems.service';
 import { LeetcodeClient } from './leetcode.client';
-import { LEETCODE_CONFIG, LeetcodeConfig } from './leetcode.config';
+import { LEETCODE_CONFIG, type LeetcodeConfig } from './leetcode.config';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -19,7 +19,7 @@ const questionDetailQuery = fs.readFileSync(
   'utf8',
 );
 
-interface RecentAcceptedItem {
+export interface RecentAcceptedItem {
   id: string;
   title: string;
   titleSlug: string;

--- a/src/leetcode/leetcode.service.ts
+++ b/src/leetcode/leetcode.service.ts
@@ -1,0 +1,136 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ProblemsService } from '../problems/problems.service';
+import { UserProblemsService } from '../user-problems/user-problems.service';
+import { LeetcodeClient } from './leetcode.client';
+import { LEETCODE_CONFIG, LeetcodeConfig } from './leetcode.config';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const recentAcSubmissionsQuery = fs.readFileSync(
+  path.join(__dirname, 'graphql/recentAcSubmissions.graphql'),
+  'utf8',
+);
+const submissionDetailQuery = fs.readFileSync(
+  path.join(__dirname, 'graphql/submissionDetail.graphql'),
+  'utf8',
+);
+const questionDetailQuery = fs.readFileSync(
+  path.join(__dirname, 'graphql/questionDetail.graphql'),
+  'utf8',
+);
+
+interface RecentAcceptedItem {
+  id: string;
+  title: string;
+  titleSlug: string;
+  timestamp: number;
+}
+
+@Injectable()
+export class LeetcodeService {
+  constructor(
+    private readonly client: LeetcodeClient,
+    private readonly problemsService: ProblemsService,
+    private readonly userProblemsService: UserProblemsService,
+    @Inject(LEETCODE_CONFIG)
+    private readonly config: LeetcodeConfig,
+  ) {}
+
+  getDefaultUsername() {
+    return this.config.username;
+  }
+
+  getDefaultPageSize() {
+    return this.config.pageSize;
+  }
+
+  async getRecentAccepted(username: string, limit = this.config.pageSize) {
+    const res = await this.client.post<{ data: { recentAcSubmissionList: any[] } }>(
+      recentAcSubmissionsQuery,
+      { username, limit },
+    );
+    return res.data.recentAcSubmissionList.map((s) => ({
+      id: String(s.id),
+      title: s.title,
+      titleSlug: s.titleSlug,
+      timestamp: Number(s.timestamp),
+    })) as RecentAcceptedItem[];
+  }
+
+  async getSubmissionDetail(submissionId: string) {
+    const res = await this.client.post<{ data: { submissionDetail: any } }>(
+      submissionDetailQuery,
+      { submissionId },
+    );
+    return res.data.submissionDetail;
+  }
+
+  async getQuestionDetail(slug: string) {
+    const res = await this.client.post<{ data: { question: any } }>(
+      questionDetailQuery,
+      { titleSlug: slug },
+    );
+    return res.data.question;
+  }
+
+  private async delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async syncRecentAccepted({
+    username,
+    limit,
+  }: {
+    username?: string;
+    limit?: number;
+  }): Promise<{ created: number; updated: number; failures: number; items: string[] }> {
+    const user = username || this.config.username;
+    const lim = limit ?? this.config.pageSize;
+    const recent = await this.getRecentAccepted(user, lim);
+    const dedupedMap = new Map<string, RecentAcceptedItem>();
+    for (const r of recent) {
+      dedupedMap.set(r.titleSlug, r);
+    }
+    const deduped = Array.from(dedupedMap.values());
+
+    let created = 0;
+    let updated = 0;
+    let failures = 0;
+    const items: string[] = [];
+
+    for (const item of deduped) {
+      await this.delay(150);
+      try {
+        const question = await this.getQuestionDetail(item.titleSlug);
+        const exists = await this.problemsService.findBySlug(item.titleSlug);
+        const problem = await this.problemsService.createOrUpdateFromLcMeta({
+          slug: item.titleSlug,
+          title: question.title,
+          difficulty: question.difficulty,
+          tags: (question.topicTags || []).map((t) => t.name),
+          description: question.content,
+        });
+        if (exists) {
+          updated++;
+        } else {
+          created++;
+        }
+
+        const submission = await this.getSubmissionDetail(item.id);
+        if (submission.statusDisplay !== 'Accepted') {
+          throw new Error('Submission not accepted');
+        }
+        const userProblem = await this.userProblemsService.linkProblemToUser(problem.id);
+        if (userProblem.interval === 0 && userProblem.repetition === 0) {
+          userProblem.interval = 1;
+        }
+        await this.userProblemsService.updateCode(userProblem.id, submission.code);
+        items.push(item.titleSlug);
+      } catch (e) {
+        failures++;
+      }
+    }
+
+    return { created, updated, failures, items };
+  }
+}

--- a/src/user-problems/user-problems.service.ts
+++ b/src/user-problems/user-problems.service.ts
@@ -105,7 +105,11 @@ export class UserProblemsService {
       }
     }
 
-    userProblem = this.userProblemRepo.create({ problem, user: user ?? undefined });
+    userProblem = this.userProblemRepo.create({
+      problem,
+      user: user ?? undefined,
+      interval: 1,
+    });
     return this.userProblemRepo.save(userProblem);
   }
 }


### PR DESCRIPTION
## Summary
- integrate LeetCode GraphQL sync with configurable client
- expose sync and preview endpoints for recent accepted submissions
- document cookie setup and mapping rules for LeetCode imports

## Testing
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6895446399dc832c804b3ee8f1abb59f