### PR TITLE
feat: import lists and review scoring

### DIFF
--- a/packages/backend/src/leetcode/dto/import-list.dto.ts
+++ b/packages/backend/src/leetcode/dto/import-list.dto.ts
@@ -1,0 +1,10 @@
+import { IsArray, ArrayNotEmpty, IsString } from 'class-validator';
+
+export class ImportListDto {
+  @IsString()
+  name: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  slugs: string[];
+}

--- a/packages/backend/src/leetcode/leetcode.controller.ts
+++ b/packages/backend/src/leetcode/leetcode.controller.ts
@@ -3,6 +3,7 @@ import { ApiBody, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { LeetcodeService } from './leetcode.service';
 import { SyncDto } from './dto/sync.dto';
 import { RecentDto } from './dto/recent.dto';
+import { ImportListDto } from './dto/import-list.dto';
 
 @ApiTags('leetcode')
 @Controller('leetcode')
@@ -13,6 +14,12 @@ export class LeetcodeController {
   @ApiBody({ type: SyncDto })
   sync(@Body() dto: SyncDto) {
     return this.service.syncRecentAccepted(dto);
+  }
+
+  @Post('list')
+  @ApiBody({ type: ImportListDto })
+  importList(@Body() dto: ImportListDto) {
+    return this.service.importList(dto.name, dto.slugs);
   }
 
   @Get('recent')

--- a/packages/backend/src/leetcode/leetcode.module.ts
+++ b/packages/backend/src/leetcode/leetcode.module.ts
@@ -5,9 +5,16 @@ import { LeetcodeClient } from './leetcode.client';
 import { loadLeetcodeConfig, LEETCODE_CONFIG } from './leetcode.config';
 import { ProblemsModule } from '../problems/problems.module';
 import { UserProblemsModule } from '../user-problems/user-problems.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProblemList } from '../problem-lists/problem-list.entity';
+import { ProblemListItem } from '../problem-list-items/problem-list-item.entity';
 
 @Module({
-  imports: [ProblemsModule, UserProblemsModule],
+  imports: [
+    ProblemsModule,
+    UserProblemsModule,
+    TypeOrmModule.forFeature([ProblemList, ProblemListItem]),
+  ],
   providers: [
     LeetcodeService,
     LeetcodeClient,

--- a/packages/backend/src/user-problems/user-problems.controller.ts
+++ b/packages/backend/src/user-problems/user-problems.controller.ts
@@ -25,6 +25,12 @@ export class UserProblemsController {
     return this.userProblemsService.getDueReviews(userId);
   }
 
+  @Get('reviews/unscored')
+  @ApiQuery({ name: 'userId', required: false })
+  getUnscored(@Query('userId') userId?: string) {
+    return this.userProblemsService.getUnscored(userId);
+  }
+
   @Post('reviews/:id')
   @ApiParam({ name: 'id', description: 'UserProblem identifier' })
   @ApiBody({ type: RateRecallDto })

--- a/packages/frontend/src/app/app.config.ts
+++ b/packages/frontend/src/app/app.config.ts
@@ -1,8 +1,13 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(appRoutes), provideAnimations()]
+  providers: [
+    provideRouter(appRoutes),
+    provideAnimations(),
+    provideHttpClient(),
+  ],
 };

--- a/packages/frontend/src/app/features/reviews/reviews.page.ts
+++ b/packages/frontend/src/app/features/reviews/reviews.page.ts
@@ -1,10 +1,74 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { NgFor, NgIf } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+
+interface UserProblem {
+  id: string;
+  problem: { title: string; difficulty: string; slug: string };
+}
 
 @Component({
   selector: 'app-reviews-page',
   standalone: true,
-  imports: [MatTableModule],
-  template: `<table mat-table [dataSource]="[]"></table>`
+  imports: [MatTableModule, MatButtonModule, NgFor, NgIf],
+  template: `
+    <div *ngIf="items.length === 0">No pending reviews</div>
+    <table mat-table [dataSource]="items" *ngIf="items.length > 0">
+      <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef>Problem</th>
+        <td mat-cell *matCellDef="let el">
+          {{ el.problem.title }} ({{ el.problem.difficulty }})
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Score</th>
+        <td mat-cell *matCellDef="let el">
+          <button mat-button *ngFor="let q of scores" (click)="rate(el.id, q)">
+            {{ q }}
+          </button>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+    <div class="mt-4">
+      <p>Scoring guide:</p>
+      <ul>
+        <li *ngFor="let q of scores">{{ q }} - {{ scoreHelp[q] }}</li>
+      </ul>
+    </div>
+  `,
 })
-export class ReviewsPage {}
+export class ReviewsPage implements OnInit {
+  items: UserProblem[] = [];
+  displayedColumns = ['title', 'actions'];
+  scores = [0, 1, 2, 3, 4, 5];
+  scoreHelp: Record<number, string> = {
+    0: 'Complete blackout',
+    1: 'Incorrect solution',
+    2: 'Partial recall',
+    3: 'Solved with effort',
+    4: 'Correct with hesitation',
+    5: 'Perfect recall',
+  };
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.http
+      .get<UserProblem[]>('/api/reviews/unscored')
+      .subscribe((res) => (this.items = res));
+  }
+
+  rate(id: string, quality: number) {
+    this.http.post(`/api/reviews/${id}`, { quality }).subscribe(() => {
+      this.items = this.items.filter((i) => i.id !== id);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- allow importing custom LeetCode lists and schedule items
- expose unscored problems and schedule reviews with SM-2
- add frontend review page to rate problems and show scoring guide

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run build` *(fails: Missing script "api:gen")*

------
https://chatgpt.com/codex/tasks/task_e_6897f8efaa24832cb5f129641dee41ab