### PR TITLE
feat: responsive shell and toolbar actions

### DIFF
--- a/packages/frontend/src/app/app-shell/app-shell.component.html
+++ b/packages/frontend/src/app/app-shell/app-shell.component.html
@@ -1,10 +1,11 @@
-<mat-sidenav-container class="app-container">
+<mat-sidenav-container class="app-container" autosize>
   <mat-sidenav
     #drawer
     [mode]="(isHandset$ | async) ? 'over' : 'side'"
     [opened]="!(isHandset$ | async)"
   >
-    <app-sidenav></app-sidenav>
+    <!-- Emit (navigate) from your <app-sidenav> when a link is clicked -->
+    <app-sidenav (navigate)="onNavItem()"></app-sidenav>
   </mat-sidenav>
 
   <mat-sidenav-content>
@@ -12,7 +13,15 @@
       title="LeetCode Tracker"
       (menu)="drawer.toggle()"
     ></app-toolbar>
-    <main class="content" [@fadeAnimation]="o.activatedRoute?.routeConfig?.path">
+
+    <!-- Guard the animation so we never touch outlet before activation -->
+    <main
+      class="content"
+      [@fadeAnimation]="o?.isActivated
+        ? (o.activatedRoute.snapshot.routeConfig?.path || 'init')
+        : 'init'"
+      tabindex="-1"
+    >
       <router-outlet #o="outlet"></router-outlet>
     </main>
   </mat-sidenav-content>

--- a/packages/frontend/src/app/app-shell/app-shell.component.html
+++ b/packages/frontend/src/app/app-shell/app-shell.component.html
@@ -1,11 +1,19 @@
 <mat-sidenav-container class="app-container">
-  <mat-sidenav #drawer mode="side" opened>
+  <mat-sidenav
+    #drawer
+    [mode]="(isHandset$ | async) ? 'over' : 'side'"
+    [opened]="!(isHandset$ | async)"
+  >
     <app-sidenav></app-sidenav>
   </mat-sidenav>
+
   <mat-sidenav-content>
-    <app-toolbar title="LeetCode Tracker" (menu)="drawer.toggle()"></app-toolbar>
-    <main class="content">
-      <router-outlet></router-outlet>
+    <app-toolbar
+      title="LeetCode Tracker"
+      (menu)="drawer.toggle()"
+    ></app-toolbar>
+    <main class="content" [@fadeAnimation]="o.activatedRoute?.routeConfig?.path">
+      <router-outlet #o="outlet"></router-outlet>
     </main>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/packages/frontend/src/app/app-shell/app-shell.component.ts
+++ b/packages/frontend/src/app/app-shell/app-shell.component.ts
@@ -1,6 +1,7 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, inject } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { Router, RouterOutlet, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
+import { AsyncPipe } from '@angular/common';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BreakpointObserver } from '@angular/cdk/layout';
@@ -16,6 +17,7 @@ import { AppSidenavComponent } from '../shared/ui/app-sidenav.component';
     RouterOutlet,
     RouterLink,
     RouterLinkActive,
+    AsyncPipe,
     MatSidenavModule,
     MatSnackBarModule,
     AppToolbarComponent,
@@ -35,14 +37,14 @@ import { AppSidenavComponent } from '../shared/ui/app-sidenav.component';
 export class AppShellComponent {
   @ViewChild('drawer') drawer!: MatSidenav;
 
+  private readonly breakpoint = inject(BreakpointObserver);
+  private readonly router = inject(Router);
+
   readonly isHandset$ = this.breakpoint
     .observe('(max-width: 768px)')
     .pipe(map(result => result.matches), shareReplay());
 
-  constructor(
-    private breakpoint: BreakpointObserver,
-    private router: Router
-  ) {
+  constructor() {
     this.router.events
       .pipe(
         filter(event => event instanceof NavigationEnd),

--- a/packages/frontend/src/app/app-shell/app-shell.component.ts
+++ b/packages/frontend/src/app/app-shell/app-shell.component.ts
@@ -5,7 +5,7 @@ import { AsyncPipe } from '@angular/common';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { map, shareReplay, filter, withLatestFrom } from 'rxjs';
+import { map, shareReplay, filter, withLatestFrom, take } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AppToolbarComponent } from '../shared/ui/app-toolbar.component';
 import { AppSidenavComponent } from '../shared/ui/app-sidenav.component';
@@ -42,9 +42,13 @@ export class AppShellComponent {
 
   readonly isHandset$ = this.breakpoint
     .observe('(max-width: 768px)')
-    .pipe(map(result => result.matches), shareReplay());
+    .pipe(
+      map(result => result.matches),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
 
   constructor() {
+    // Close drawer on navigation when in handset
     this.router.events
       .pipe(
         filter(event => event instanceof NavigationEnd),
@@ -53,5 +57,12 @@ export class AppShellComponent {
         takeUntilDestroyed()
       )
       .subscribe(() => this.drawer.close());
+  }
+
+  // Called when a nav item is clicked; one-shot read avoids DI context issues
+  onNavItem() {
+    this.isHandset$.pipe(take(1)).subscribe(isHandset => {
+      if (isHandset) this.drawer.close();
+    });
   }
 }

--- a/packages/frontend/src/app/app-shell/app-shell.component.ts
+++ b/packages/frontend/src/app/app-shell/app-shell.component.ts
@@ -1,7 +1,11 @@
-import { Component } from '@angular/core';
-import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
-import { MatSidenavModule } from '@angular/material/sidenav';
+import { Component, ViewChild } from '@angular/core';
+import { trigger, transition, style, animate } from '@angular/animations';
+import { Router, RouterOutlet, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
+import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { map, shareReplay, filter, withLatestFrom } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AppToolbarComponent } from '../shared/ui/app-toolbar.component';
 import { AppSidenavComponent } from '../shared/ui/app-sidenav.component';
 
@@ -18,6 +22,34 @@ import { AppSidenavComponent } from '../shared/ui/app-sidenav.component';
     AppSidenavComponent
   ],
   templateUrl: './app-shell.component.html',
-  styleUrls: ['./app-shell.component.scss']
+  styleUrls: ['./app-shell.component.scss'],
+  animations: [
+    trigger('fadeAnimation', [
+      transition('* <=> *', [
+        style({ opacity: 0 }),
+        animate('200ms ease-in-out', style({ opacity: 1 }))
+      ])
+    ])
+  ]
 })
-export class AppShellComponent {}
+export class AppShellComponent {
+  @ViewChild('drawer') drawer!: MatSidenav;
+
+  readonly isHandset$ = this.breakpoint
+    .observe('(max-width: 768px)')
+    .pipe(map(result => result.matches), shareReplay());
+
+  constructor(
+    private breakpoint: BreakpointObserver,
+    private router: Router
+  ) {
+    this.router.events
+      .pipe(
+        filter(event => event instanceof NavigationEnd),
+        withLatestFrom(this.isHandset$),
+        filter(([_, handset]) => handset),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => this.drawer.close());
+  }
+}

--- a/packages/frontend/src/app/core/theme-toggle.component.ts
+++ b/packages/frontend/src/app/core/theme-toggle.component.ts
@@ -1,23 +1,110 @@
 import { Component } from '@angular/core';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { ThemeService } from './theme.service';
+
+type Theme = 'white' | 'high-contrast-dark' | 'eink' | 'eink-dark';
 
 @Component({
   selector: 'app-theme-toggle',
   standalone: true,
-  imports: [MatSlideToggleModule, MatIconModule],
+  imports: [MatMenuModule, MatButtonModule, MatIconModule, MatTooltipModule],
   template: `
-    <mat-slide-toggle
-      [checked]="theme.isDark()"
-      (change)="theme.toggle()"
-      aria-label="Toggle theme"
-      class="theme-toggle">
-      <mat-icon>{{ theme.isDark() ? 'dark_mode' : 'light_mode' }}</mat-icon>
-    </mat-slide-toggle>
+    <!-- Toolbar button that shows current theme; opens menu -->
+    <button
+      mat-icon-button
+      [matMenuTriggerFor]="themeMenu"
+      [attr.aria-label]="'Change theme (current: ' + labelFor(current) + ')'"
+      matTooltip="Theme"
+      class="theme-btn"
+    >
+      <mat-icon aria-hidden="true">{{ iconFor(current) }}</mat-icon>
+    </button>
+
+    <mat-menu #themeMenu="matMenu">
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        [attr.aria-checked]="current==='white'"
+        (click)="set('white')"
+      >
+        <mat-icon aria-hidden="true">light_mode</mat-icon>
+        <span>Light</span>
+        <span class="spacer"></span>
+        <mat-icon *ngIf="current==='white'" aria-hidden="true">check</mat-icon>
+      </button>
+
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        [attr.aria-checked]="current==='high-contrast-dark'"
+        (click)="set('high-contrast-dark')"
+      >
+        <mat-icon aria-hidden="true">brightness_4</mat-icon>
+        <span>High Contrast</span>
+        <span class="spacer"></span>
+        <mat-icon *ngIf="current==='high-contrast-dark'" aria-hidden="true">check</mat-icon>
+      </button>
+
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        [attr.aria-checked]="current==='eink'"
+        (click)="set('eink')"
+      >
+        <mat-icon aria-hidden="true">menu_book</mat-icon>
+        <span>E-Ink (B/W)</span>
+        <span class="spacer"></span>
+        <mat-icon *ngIf="current==='eink'" aria-hidden="true">check</mat-icon>
+      </button>
+
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        [attr.aria-checked]="current==='eink-dark'"
+        (click)="set('eink-dark')"
+      >
+        <mat-icon aria-hidden="true">menu_book</mat-icon>
+        <span>E-Ink Dark (B/W)</span>
+        <span class="spacer"></span>
+        <mat-icon *ngIf="current==='eink-dark'" aria-hidden="true">check</mat-icon>
+      </button>
+    </mat-menu>
   `,
-  styles: [`.theme-toggle{margin-left:auto;}`]
+  styles: [`
+    :host { display: inline-flex; }
+    .theme-btn { margin-left: auto; }
+    .spacer { flex: 1 1 auto; }
+  `]
 })
 export class ThemeToggleComponent {
   constructor(public theme: ThemeService) {}
+
+  get current(): Theme {
+    return this.theme.getTheme() as Theme;
+  }
+
+  set(t: Theme) {
+    this.theme.setTheme(t);
+  }
+
+  iconFor(t: Theme) {
+    switch (t) {
+      case 'white': return 'light_mode';
+      case 'eink':
+      case 'eink-dark': return 'menu_book';
+      default: return 'brightness_4';
+    }
+  }
+
+  labelFor(t: Theme) {
+    switch (t) {
+      case 'white': return 'Light';
+      case 'eink': return 'E-Ink (B/W)';
+      case 'eink-dark': return 'E-Ink Dark (B/W)';
+      default: return 'High Contrast';
+    }
+  }
 }

--- a/packages/frontend/src/app/core/theme.service.ts
+++ b/packages/frontend/src/app/core/theme.service.ts
@@ -1,6 +1,7 @@
+// src/app/core/theme.service.ts
 import { Injectable } from '@angular/core';
 
-type Theme = 'white' | 'high-contrast-dark';
+export type Theme = 'white' | 'high-contrast-dark' | 'eink' | 'eink-dark';
 
 @Injectable({ providedIn: 'root' })
 export class ThemeService {
@@ -9,32 +10,40 @@ export class ThemeService {
 
   constructor() {
     const saved = (localStorage.getItem(this.storageKey) as Theme) || null;
-    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const prefersDark =
+      window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
+
+    // default to E-Ink? keep your current logic; I’ll default to light
     this.current = saved ?? (prefersDark ? 'high-contrast-dark' : 'white');
     this.applyTheme(this.current);
   }
 
-  getTheme(): Theme {
-    return this.current;
-  }
-
+  getTheme(): Theme { return this.current; }
+  isDark(): boolean { return this.current === 'high-contrast-dark'; }
   setTheme(theme: Theme): void {
     this.current = theme;
     localStorage.setItem(this.storageKey, theme);
     this.applyTheme(theme);
   }
-
   toggle(): void {
     this.setTheme(this.isDark() ? 'white' : 'high-contrast-dark');
   }
 
-  isDark(): boolean {
-    return this.current === 'high-contrast-dark';
-  }
-
   private applyTheme(theme: Theme): void {
-    const body = document.body.classList;
-    body.remove('theme-white', 'theme-high-contrast-dark');
-    body.add(theme === 'white' ? 'theme-white' : 'theme-high-contrast-dark');
-  }
+  const classes = ['theme-white','theme-high-contrast-dark','theme-eink','theme-eink-dark'];
+  document.documentElement.classList.remove(...classes);
+  document.body.classList.remove(...classes);
+
+  const cls =
+    theme === 'white' ? 'theme-white' :
+    theme === 'eink'  ? 'theme-eink'  :
+    theme === 'eink-dark' ? 'theme-eink-dark' :
+    'theme-high-contrast-dark';
+
+  document.documentElement.classList.add(cls);
+  document.body.classList.add(cls);
+
+  document.documentElement.style.colorScheme =
+    (theme === 'high-contrast-dark' || theme === 'eink-dark') ? 'dark' : 'light';
+}
 }

--- a/packages/frontend/src/app/features/dashboard/dashboard.page.html
+++ b/packages/frontend/src/app/features/dashboard/dashboard.page.html
@@ -1,6 +1,11 @@
-<div class="stats">
-  <mat-card *ngFor="let s of stats">
-    <mat-card-title>{{ s.label }}</mat-card-title>
-    <mat-card-content>{{ s.value }}</mat-card-content>
+<section class="stats">
+  <mat-card class="stat" *ngFor="let s of stats; trackBy: trackByLabel" appearance="outlined">
+    <mat-card-header>
+      <mat-icon class="avatar" aria-hidden="true">{{ s.icon }}</mat-icon>
+      <div class="titles">
+        <mat-card-subtitle>{{ s.label }}</mat-card-subtitle>
+        <mat-card-title>{{ s.value }}</mat-card-title>
+      </div>
+    </mat-card-header>
   </mat-card>
-</div>
+</section>

--- a/packages/frontend/src/app/features/dashboard/dashboard.page.scss
+++ b/packages/frontend/src/app/features/dashboard/dashboard.page.scss
@@ -1,5 +1,50 @@
+:host {
+  --gap: clamp(12px, 2vw, 20px);
+}
+
 .stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: var(--gap);
+}
+
+.stat {
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--mat-elevation-shadow-level-2, 0 2px 8px rgba(0,0,0,.15));
+  }
+
+  mat-card-header {
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+  }
+
+  .avatar {
+    font-size: 20px;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    display: grid;
+    place-items: center;
+    background: var(--mat-sys-secondary-container, rgba(0,0,0,.06));
+    color: var(--mat-sys-on-secondary-container, currentColor);
+  }
+
+  .titles {
+    display: grid;
+    gap: 2px;
+  }
+
+  mat-card-subtitle {
+    opacity: .8;
+    font-size: .8rem;
+  }
+
+  mat-card-title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
 }

--- a/packages/frontend/src/app/features/list-detail/list-detail.page.html
+++ b/packages/frontend/src/app/features/list-detail/list-detail.page.html
@@ -1,23 +1,52 @@
-<ng-container *ngIf="list$ | async as list">
+<ng-container *ngIf="list$ | async as list; else loading">
   <h2>{{ list.name }}</h2>
+
+  <table
+    mat-table
+    [dataSource]="(rows$ | async) ?? []"
+    class="list-table"
+    aria-label="List items"
+  >
+    <!-- Title -->
+    <ng-container matColumnDef="title">
+      <th mat-header-cell *matHeaderCellDef> Title </th>
+      <td mat-cell *matCellDef="let row">{{ row.title }}</td>
+    </ng-container>
+
+    <!-- Tags -->
+    <ng-container matColumnDef="tags">
+      <th mat-header-cell *matHeaderCellDef> Tags </th>
+      <td mat-cell *matCellDef="let row">
+        <app-tag-chip
+          *ngFor="let t of row.tags; trackBy: trackByTag"
+          [tag]="t"
+        ></app-tag-chip>
+      </td>
+    </ng-container>
+
+    <!-- Difficulty -->
+    <ng-container matColumnDef="difficulty">
+      <th mat-header-cell *matHeaderCellDef> Difficulty </th>
+      <td mat-cell *matCellDef="let row">
+        <app-difficulty-pill [difficulty]="row.difficulty"></app-difficulty-pill>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr
+      mat-row
+      *matRowDef="let row; columns: displayedColumns; trackBy: trackById"
+    ></tr>
+
+    <!-- Empty state -->
+    <tr class="no-data" mat-row *matNoDataRow>
+      <td class="no-data-cell" [attr.colspan]="displayedColumns.length">
+        This list has no problems yet.
+      </td>
+    </tr>
+  </table>
 </ng-container>
-<table mat-table [dataSource]="[]" class="list-table">
-  <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef>Title</th>
-    <td mat-cell *matCellDef="let row">{{ row.title }}</td>
-  </ng-container>
-  <ng-container matColumnDef="tags">
-    <th mat-header-cell *matHeaderCellDef>Tags</th>
-    <td mat-cell *matCellDef="let row">
-      <app-tag-chip *ngFor="let t of row.tags" [tag]="t"></app-tag-chip>
-    </td>
-  </ng-container>
-  <ng-container matColumnDef="difficulty">
-    <th mat-header-cell *matHeaderCellDef>Difficulty</th>
-    <td mat-cell *matCellDef="let row">
-      <app-difficulty-pill [difficulty]="row.difficulty"></app-difficulty-pill>
-    </td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-</table>
+
+<ng-template #loading>
+  <h2>Loading…</h2>
+</ng-template>

--- a/packages/frontend/src/app/features/list-detail/list-detail.page.scss
+++ b/packages/frontend/src/app/features/list-detail/list-detail.page.scss
@@ -1,3 +1,11 @@
 .list-table {
   width: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.no-data .no-data-cell {
+  text-align: center;
+  padding: 16px;
+  opacity: 0.8;
 }

--- a/packages/frontend/src/app/features/lists/lists.page.html
+++ b/packages/frontend/src/app/features/lists/lists.page.html
@@ -1,21 +1,81 @@
-<div class="actions">
-  <button mat-raised-button color="primary" (click)="import()">Import List</button>
-</div>
-<mat-list>
-  <mat-list-item *ngFor="let list of (lists$ | async) ?? []">
-    {{ list.name }}
-  </mat-list-item>
-</mat-list>
+<!-- Busy indicator -->
+<mat-progress-bar *ngIf="isBusy" mode="indeterminate"></mat-progress-bar>
 
+<div class="actions">
+  <button mat-raised-button color="primary" (click)="openImportDialog()">
+    Import List
+  </button>
+</div>
+
+<!-- Lists -->
+<ng-container *ngIf="(lists$ | async) as lists; else loading">
+  <mat-list *ngIf="lists.length; else empty">
+    <mat-list-item
+      *ngFor="let list of lists; trackBy: trackById"
+      [routerLink]="['/lists', list.id]"
+    >
+      <mat-icon matListItemIcon aria-hidden="true">list</mat-icon>
+      <div matListItemTitle>{{ list.name }}</div>
+      <div matListItemLine *ngIf="list.description">{{ list.description }}</div>
+      <mat-icon matListItemMeta aria-hidden="true">chevron_right</mat-icon>
+    </mat-list-item>
+  </mat-list>
+</ng-container>
+
+<ng-template #loading>
+  <mat-list>
+    <mat-list-item><div class="shim"></div></mat-list-item>
+    <mat-list-item><div class="shim"></div></mat-list-item>
+    <mat-list-item><div class="shim"></div></mat-list-item>
+  </mat-list>
+</ng-template>
+
+<ng-template #empty>
+  <div class="empty">
+    <mat-icon aria-hidden="true">inbox</mat-icon>
+    <p>No lists yet.</p>
+    <button mat-stroked-button color="primary" (click)="openImportDialog()">
+      Import your first list
+    </button>
+  </div>
+</ng-template>
+
+<!-- Import dialog template -->
 <ng-template #importDialog>
   <h1 mat-dialog-title>Import List</h1>
-  <div mat-dialog-content>
-    <mat-form-field appearance="fill">
-      <input matInput placeholder="List URL or slug" [(ngModel)]="importUrl" />
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions>
-    <button mat-button mat-dialog-close>Cancel</button>
-    <button mat-raised-button color="primary" [mat-dialog-close]="importUrl">Import</button>
-  </div>
+
+  <form (ngSubmit)="confirmImport()" #f="ngForm">
+    <div mat-dialog-content>
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label>List URL or slug</mat-label>
+        <input
+          matInput
+          name="importUrl"
+          [(ngModel)]="importUrl"
+          required
+          [pattern]="importPattern"
+          placeholder="e.g. https://… or my/fav-list"
+          (keyup.enter)="confirmImport()"
+          #urlCtrl="ngModel"
+          autofocus
+        />
+        <mat-error *ngIf="urlCtrl.invalid && urlCtrl.touched">
+          Please enter a valid URL or slug.
+        </mat-error>
+      </mat-form-field>
+    </div>
+
+    <div mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close type="button">Cancel</button>
+      <button
+        mat-raised-button
+        color="primary"
+        [disabled]="!isValidImport(importUrl)"
+        [mat-dialog-close]="importUrl"
+        type="submit"
+      >
+        Import
+      </button>
+    </div>
+  </form>
 </ng-template>

--- a/packages/frontend/src/app/features/lists/lists.page.scss
+++ b/packages/frontend/src/app/features/lists/lists.page.scss
@@ -1,3 +1,26 @@
-.actions {
-  margin-bottom: 1rem;
+.actions { margin-bottom: 1rem; }
+
+.empty {
+  display: grid;
+  place-items: center;
+  gap: 8px;
+  padding: 32px 0;
+  opacity: 0.9;
+
+  mat-icon { font-size: 40px; }
+}
+
+.w-100 { width: 100%; }
+
+.shim {
+  height: 16px;
+  width: 60%;
+  border-radius: 8px;
+  background: linear-gradient(90deg, rgba(0,0,0,.08) 25%, rgba(0,0,0,.14) 37%, rgba(0,0,0,.08) 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.1s ease-in-out infinite;
+}
+@keyframes shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: 0 0; }
 }

--- a/packages/frontend/src/app/features/lists/lists.page.ts
+++ b/packages/frontend/src/app/features/lists/lists.page.ts
@@ -1,11 +1,15 @@
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
-import { AsyncPipe, NgFor } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { FormsModule } from '@angular/forms';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+
 import { ListsFacade } from '../../core/lists.facade';
 import { UiList } from '../../core/models';
 import { Observable } from 'rxjs';
@@ -14,24 +18,38 @@ import { Observable } from 'rxjs';
   selector: 'app-lists-page',
   standalone: true,
   imports: [
+    // UI
     MatListModule,
     MatButtonModule,
-    NgFor,
-    AsyncPipe,
+    MatIconModule,
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
-    FormsModule,
+    MatProgressBarModule,
+    MatSnackBarModule,
+
+    // Angular
+    RouterLink,
+    NgFor,
+    NgIf,
+    AsyncPipe,
   ],
   templateUrl: './lists.page.html',
-  styleUrls: ['./lists.page.scss']
+  styleUrls: ['./lists.page.scss'],
 })
 export class ListsPage implements OnInit {
   lists$!: Observable<UiList[]>;
   importUrl = '';
+  isBusy = false;
+
+  /** Accept http(s)://… OR a slug like "folder/name" or "my-list" */
+  readonly importPattern = '^(https?://\\S+|[A-Za-z0-9](?:[A-Za-z0-9\\-/]*))$';
+
   @ViewChild('importDialog') importDialog!: TemplateRef<any>;
 
-  constructor(private dialog: MatDialog, private facade: ListsFacade) {}
+  private dialog = inject(MatDialog);
+  private facade = inject(ListsFacade);
+  private snack = inject(MatSnackBar);
 
   ngOnInit() {
     this.load();
@@ -41,13 +59,44 @@ export class ListsPage implements OnInit {
     this.lists$ = this.facade.getLists();
   }
 
-  import() {
+  openImportDialog() {
     this.importUrl = '';
-    const ref = this.dialog.open(this.importDialog);
-    ref.afterClosed().subscribe((url: string) => {
-      if (url) {
-        this.facade.importList(url).subscribe(() => this.load());
-      }
+    this.dialog.open(this.importDialog, { width: '480px' })
+      .afterClosed()
+      .subscribe((url: string | null | undefined) => {
+        if (url && this.isValidImport(url)) {
+          this.doImport(url);
+        }
+      });
+  }
+
+  confirmImport() {
+    // handled by [mat-dialog-close]; keep for Enter key fallback if needed
+  }
+
+  isValidImport(val: string | null | undefined): boolean {
+    if (!val) return false;
+    const re = new RegExp(this.importPattern);
+    return re.test(val.trim());
+  }
+
+  private doImport(url: string) {
+    this.isBusy = true;
+    this.snack.open('Importing list…', undefined, { duration: 1500 });
+
+    this.facade.importList(url).subscribe({
+      next: () => {
+        this.isBusy = false;
+        this.snack.open('List imported', 'Dismiss', { duration: 2500 });
+        this.load();
+      },
+      error: (err) => {
+        this.isBusy = false;
+        console.error(err);
+        this.snack.open('Import failed. Check URL/slug and try again.', 'Dismiss', { duration: 3500 });
+      },
     });
   }
+
+  trackById = (_: number, list: UiList) => (list as any).id ?? (list as any).slug ?? list.name;
 }

--- a/packages/frontend/src/app/features/problem-detail/problem-detail.page.html
+++ b/packages/frontend/src/app/features/problem-detail/problem-detail.page.html
@@ -1,22 +1,50 @@
 <ng-container *ngIf="problem$ | async as problem">
   <mat-card>
-    <mat-card-title>{{ problem.title }}</mat-card-title>
-    <mat-card-subtitle>
-      <app-difficulty-pill [difficulty]="problem.difficulty"></app-difficulty-pill>
-      <app-tag-chip *ngFor="let t of problem.tags" [tag]="t"></app-tag-chip>
-    </mat-card-subtitle>
+    <mat-card-header>
+      <div>
+        <mat-card-title>{{ problem.title }}</mat-card-title>
+        <mat-card-subtitle class="meta">
+          <app-difficulty-pill [difficulty]="problem.difficulty"></app-difficulty-pill>
+          <app-tag-chip *ngFor="let t of problem.tags" [tag]="t"></app-tag-chip>
+        </mat-card-subtitle>
+      </div>
+    </mat-card-header>
+
     <mat-card-actions>
-      <button mat-button (click)="rate(problem)">Rate Recall</button>
+      <button mat-raised-button color="primary" (click)="rate(problem)">Rate Recall</button>
     </mat-card-actions>
+
     <mat-tab-group>
       <mat-tab label="Description">
-        <div class="pad">{{ problem.description }}</div>
-      </mat-tab>
-      <mat-tab label="Notes">
-        <div class="pad">
-          <textarea matInput [(ngModel)]="notes" placeholder="Notes"></textarea>
-          <button mat-button (click)="saveNotes(problem.id)">Save</button>
+        <div class="pad description">
+          {{ problem.description }}
         </div>
+      </mat-tab>
+
+      <mat-tab label="Notes">
+        <form class="pad" (ngSubmit)="saveNotes(problem.id)">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Notes</mat-label>
+            <textarea
+              matInput
+              name="notes"
+              [(ngModel)]="notes"
+              cdkTextareaAutosize
+              [cdkAutosizeMinRows]="4"
+              [cdkAutosizeMaxRows]="20"
+              placeholder="Add your insights, pitfalls, time/space, gotchas…"
+              [disabled]="saving"
+            ></textarea>
+          </mat-form-field>
+
+          <div class="note-actions">
+            <button mat-stroked-button type="button" (click)="notes=''" [disabled]="saving">Clear</button>
+            <span class="spacer"></span>
+            <button mat-raised-button color="primary" type="submit" [disabled]="saving || !notesChanged">
+              {{ saving ? 'Saving…' : 'Save' }}
+            </button>
+          </div>
+        </form>
       </mat-tab>
     </mat-tab-group>
   </mat-card>

--- a/packages/frontend/src/app/features/problem-detail/problem-detail.page.scss
+++ b/packages/frontend/src/app/features/problem-detail/problem-detail.page.scss
@@ -1,3 +1,20 @@
-.pad {
-  padding: 1rem;
+.pad { padding: 1rem; }
+
+.description {
+  white-space: pre-wrap; /* keep formatting of long text */
+  line-height: 1.5;
+}
+
+.meta app-tag-chip {
+  margin-inline-start: 6px;
+}
+
+.w-100 { width: 100%; }
+
+.note-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .spacer { flex: 1 1 auto; }
 }

--- a/packages/frontend/src/app/features/problem-detail/problem-detail.page.ts
+++ b/packages/frontend/src/app/features/problem-detail/problem-detail.page.ts
@@ -1,55 +1,101 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { FormsModule } from '@angular/forms'; // ✅ correct source
+import { ActivatedRoute } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatInputModule } from '@angular/material/input';
-import { FormsModule } from '@angular/forms';
+import { TextFieldModule } from '@angular/cdk/text-field';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
 import { DifficultyPillComponent } from '../../shared/ui/difficulty-pill/difficulty-pill.component';
 import { TagChipComponent } from '../../shared/ui/tag-chip/tag-chip.component';
-import { AsyncPipe, NgFor, NgIf } from '@angular/common';
-import { ActivatedRoute } from '@angular/router';
-import { Observable } from 'rxjs';
-import { UiProblem } from '../../core/models';
 import { ProblemsFacade } from '../../core/problems.facade';
 import { ReviewsFacade } from '../../core/reviews.facade';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDialog } from '@angular/material/dialog';
+import { UiProblem } from '../../core/models';
+import { Observable, map, switchMap, filter, of } from 'rxjs';
 import { RateDialogComponent } from '../../shared/ui/rate-dialog/rate-dialog.component';
 
 @Component({
   selector: 'app-problem-detail-page',
   standalone: true,
-  imports: [MatCardModule, MatTabsModule, MatInputModule, FormsModule, MatButtonModule, DifficultyPillComponent, TagChipComponent, NgFor, NgIf, AsyncPipe],
+  imports: [
+    // Angular
+    NgIf, NgFor, AsyncPipe, FormsModule,
+
+    // Material
+    MatCardModule, MatTabsModule, MatInputModule, TextFieldModule,
+    MatButtonModule, MatDialogModule, MatSnackBarModule,
+
+    // Custom
+    DifficultyPillComponent, TagChipComponent,
+  ],
   templateUrl: './problem-detail.page.html',
   styleUrls: ['./problem-detail.page.scss']
 })
 export class ProblemDetailPage implements OnInit {
-  problem$!: Observable<UiProblem>;
-  notes = '';
+  private route = inject(ActivatedRoute);
+  private problems = inject(ProblemsFacade);
+  private reviews = inject(ReviewsFacade);
+  private dialog = inject(MatDialog);
+  private snack = inject(MatSnackBar);
 
-  constructor(
-    private route: ActivatedRoute,
-    private problems: ProblemsFacade,
-    private reviews: ReviewsFacade,
-    private dialog: MatDialog
-  ) {}
+  problem$!: Observable<UiProblem>;
+
+  // notes + UX state
+  notes = '';
+  private originalNotes = signal<string>(''); // if you later load existing notes, set this
+  saving = false;
+  notesChanged = computed(() => this.notes !== this.originalNotes());
 
   ngOnInit() {
-    const slug = this.route.snapshot.paramMap.get('slug')!;
-    this.problem$ = this.problems.getBySlug(slug);
+    // Load the problem reactively so it updates if slug changes
+    this.problem$ = this.route.paramMap.pipe(
+      map(params => params.get('slug')!),
+      switchMap(slug => this.problems.getBySlug(slug))
+    );
+
+    // Optional: if you have an API to get existing notes, set both notes + originalNotes here.
+    // this.problem$.pipe(
+    //   switchMap(p => this.reviews.getNotes(p.id))
+    // ).subscribe(n => {
+    //   this.notes = n ?? '';
+    //   this.originalNotes.set(this.notes);
+    // });
   }
 
   saveNotes(problemId: string) {
-    this.reviews.updateNotes(problemId, this.notes).subscribe();
+    this.saving = true;
+    this.reviews.updateNotes(problemId, this.notes).subscribe({
+      next: () => {
+        this.originalNotes.set(this.notes);
+        this.snack.open('Notes saved', undefined, { duration: 1800 });
+        this.saving = false;
+      },
+      error: () => {
+        this.snack.open('Failed to save notes', 'Dismiss', { duration: 2500 });
+        this.saving = false;
+      }
+    });
   }
 
+  /** Open dialog first; only link + rate if user actually chose a quality */
   rate(problem: UiProblem) {
-    this.reviews.linkProblem(problem.id).subscribe(userProblemId => {
-      const ref = this.dialog.open(RateDialogComponent, { data: { title: problem.title } });
-      ref.afterClosed().subscribe(quality => {
-        if (quality != null) {
-          this.reviews.rateRecall(userProblemId, quality).subscribe();
-        }
+    this.dialog.open(RateDialogComponent, { data: { title: problem.title } })
+      .afterClosed()
+      .pipe(
+        filter(q => q != null),
+        switchMap(quality =>
+          this.reviews.linkProblem(problem.id).pipe(
+            switchMap(userProblemId => this.reviews.rateRecall(userProblemId, quality))
+          )
+        )
+      )
+      .subscribe({
+        next: () => this.snack.open('Recall rated', undefined, { duration: 1500 }),
+        error: () => this.snack.open('Failed to submit rating', 'Dismiss', { duration: 2500 })
       });
-    });
   }
 }

--- a/packages/frontend/src/app/features/problems/problems.page.html
+++ b/packages/frontend/src/app/features/problems/problems.page.html
@@ -1,33 +1,86 @@
 <div class="filters">
-  <mat-form-field appearance="fill">
-    <mat-label>Search</mat-label>
-    <input matInput />
+  <mat-form-field appearance="fill" class="search">
+    <mat-label>Search title</mat-label>
+    <input
+      matInput
+      type="search"
+      [value]="search"
+      (input)="onSearch($any($event.target).value)"
+      placeholder="e.g. Two Sum"
+    />
+    <button
+      *ngIf="search"
+      mat-icon-button
+      matSuffix
+      aria-label="Clear search"
+      (click)="onSearch('')"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
   </mat-form-field>
-  <mat-form-field appearance="fill">
+
+  <mat-form-field appearance="fill" class="difficulty">
     <mat-label>Difficulty</mat-label>
-    <mat-select>
+    <mat-select [value]="selectedDifficulty" (selectionChange)="onDifficultyChange($event.value)">
+      <mat-option [value]="''">All</mat-option>
       <mat-option *ngFor="let d of difficulties" [value]="d">{{ d }}</mat-option>
     </mat-select>
   </mat-form-field>
-  <button mat-button>Filter</button>
+
+  <button
+    mat-stroked-button
+    class="clear"
+    (click)="clearFilters()"
+    [disabled]="!search && !selectedDifficulty"
+  >
+    Clear
+  </button>
 </div>
-<table mat-table [dataSource]="(problems$ | async) ?? []" class="problems-table">
+
+<table
+  mat-table
+  [dataSource]="problemsDS"
+  matSort
+  class="problems-table"
+  aria-label="Problems"
+>
+  <!-- Title -->
   <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef>Title</th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Title</th>
     <td mat-cell *matCellDef="let row">{{ row.title }}</td>
   </ng-container>
+
+  <!-- Tags -->
   <ng-container matColumnDef="tags">
     <th mat-header-cell *matHeaderCellDef>Tags</th>
     <td mat-cell *matCellDef="let row">
-      <app-tag-chip *ngFor="let t of row.tags" [tag]="t"></app-tag-chip>
+      <app-tag-chip *ngFor="let t of row.tags; trackBy: trackByTag" [tag]="t"></app-tag-chip>
     </td>
   </ng-container>
+
+  <!-- Difficulty -->
   <ng-container matColumnDef="difficulty">
-    <th mat-header-cell *matHeaderCellDef>Difficulty</th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Difficulty</th>
     <td mat-cell *matCellDef="let row">
       <app-difficulty-pill [difficulty]="row.difficulty"></app-difficulty-pill>
     </td>
   </ng-container>
+
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+  <!-- Empty state -->
+  <tr class="no-data" mat-row *matNoDataRow>
+    <td class="no-data-cell" [attr.colspan]="displayedColumns.length">
+      No problems match your filters.
+    </td>
+  </tr>
 </table>
+
+<mat-paginator
+  [length]="problemsDS?.filteredData?.length || 0"
+  [pageSize]="10"
+  [pageSizeOptions]="[5, 10, 25, 50]"
+  showFirstLastButtons
+  aria-label="Problems paginator"
+></mat-paginator>

--- a/packages/frontend/src/app/features/problems/problems.page.scss
+++ b/packages/frontend/src/app/features/problems/problems.page.scss
@@ -1,10 +1,29 @@
 .filters {
-  display: flex;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: 1fr minmax(200px, 240px) auto;
+  gap: 12px;
   margin-bottom: 1rem;
   align-items: center;
+
+  .search { width: 100%; }
+  .difficulty { width: 100%; }
+}
+
+@media (max-width: 720px) {
+  .filters {
+    grid-template-columns: 1fr;
+    .clear { justify-self: start; }
+  }
 }
 
 .problems-table {
   width: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.no-data .no-data-cell {
+  text-align: center;
+  padding: 16px;
+  opacity: 0.8;
 }

--- a/packages/frontend/src/app/features/problems/problems.page.ts
+++ b/packages/frontend/src/app/features/problems/problems.page.ts
@@ -1,41 +1,136 @@
-import { Component, OnInit } from '@angular/core';
-import { MatTableModule } from '@angular/material/table';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  AfterViewInit,
+  inject,
+} from '@angular/core';
+import { AsyncPipe, NgFor } from '@angular/common';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { AsyncPipe, NgFor } from '@angular/common';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatIconModule } from '@angular/material/icon';
+
 import { DifficultyPillComponent } from '../../shared/ui/difficulty-pill/difficulty-pill.component';
 import { TagChipComponent } from '../../shared/ui/tag-chip/tag-chip.component';
 import { UiProblem, Difficulty } from '../../core/models';
 import { ProblemsFacade } from '../../core/problems.facade';
-import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-problems-page',
   standalone: true,
   imports: [
+    // table + controls
     MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
     MatButtonModule,
+    MatIconModule,
+
+    // utils
     NgFor,
-    AsyncPipe,
+
+    // custom cells
     DifficultyPillComponent,
-    TagChipComponent
+    TagChipComponent,
   ],
   templateUrl: './problems.page.html',
-  styleUrls: ['./problems.page.scss']
+  styleUrls: ['./problems.page.scss'],
 })
-export class ProblemsPage implements OnInit {
+export class ProblemsPage implements OnInit, AfterViewInit {
   displayedColumns = ['title', 'tags', 'difficulty'];
-  problems$!: Observable<UiProblem[]>;
-  difficulties = Object.values(Difficulty);
 
-  constructor(private facade: ProblemsFacade) {}
+  // MatTableDataSource to enable filter/sort/pagination
+  problemsDS = new MatTableDataSource<UiProblem>([]);
+
+  // filters
+  difficulties = Object.values(Difficulty);
+  search = '';
+  selectedDifficulty: Difficulty | '' = '';
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  private facade = inject(ProblemsFacade);
 
   ngOnInit() {
-    this.problems$ = this.facade.list();
+    // Load data
+    this.facade.list().subscribe(items => {
+      this.problemsDS.data = items ?? [];
+      this.applyFilters();
+    });
+
+    // Custom filter combining search + difficulty
+    this.problemsDS.filterPredicate = (row, filterStr) => {
+      let f: { search: string; difficulty: string };
+      try {
+        f = JSON.parse(filterStr || '{}');
+      } catch {
+        f = { search: '', difficulty: '' };
+      }
+      const s = (f.search || '').trim().toLowerCase();
+      const d = (f.difficulty || '').toString();
+
+      const matchesSearch =
+        !s ||
+        (row.title || '').toLowerCase().includes(s) ||
+        (row.tags || []).some(t => (t || '').toLowerCase().includes(s));
+
+      const matchesDifficulty = !d || row.difficulty === d;
+
+      return matchesSearch && matchesDifficulty;
+    };
   }
+
+  ngAfterViewInit() {
+    this.problemsDS.paginator = this.paginator;
+    this.problemsDS.sort = this.sort;
+
+    // Optional: default sort by title asc
+    setTimeout(() => {
+      if (this.sort) {
+        this.sort.active = 'title';
+        this.sort.direction = 'asc';
+        this.sort.sortChange.emit({ active: 'title', direction: 'asc' });
+      }
+    });
+  }
+
+  // Handlers
+  onSearch(val: string) {
+    this.search = val ?? '';
+    this.applyFilters(true);
+  }
+
+  onDifficultyChange(val: Difficulty | '') {
+    this.selectedDifficulty = val ?? '';
+    this.applyFilters(true);
+  }
+
+  clearFilters() {
+    this.search = '';
+    this.selectedDifficulty = '';
+    this.applyFilters(true);
+  }
+
+  private applyFilters(resetPage = false) {
+    this.problemsDS.filter = JSON.stringify({
+      search: this.search,
+      difficulty: this.selectedDifficulty,
+    });
+
+    if (resetPage && this.problemsDS.paginator) {
+      this.problemsDS.paginator.firstPage();
+    }
+  }
+
+  // TrackBy for tags in cell ngFor (perf)
+  trackByTag = (_: number, t: string) => t;
 }

--- a/packages/frontend/src/app/features/reviews/reviews.page.html
+++ b/packages/frontend/src/app/features/reviews/reviews.page.html
@@ -1,67 +1,183 @@
-<section>
-  <h2>Unscored</h2>
-  <table mat-table [dataSource]="(unscored$ | async) ?? []" class="reviews-table">
+<!-- 1) DUE REVIEWS FIRST -->
+<section class="section">
+  <h2>Due Reviews</h2>
+
+  <table
+    mat-table
+    [dataSource]="(reviews$ | async) ?? []"
+    class="reviews-table"
+    aria-label="Due reviews"
+  >
+    <!-- Title -->
     <ng-container matColumnDef="title">
-      <th mat-header-cell *matHeaderCellDef>Title</th>
+      <th mat-header-cell *matHeaderCellDef> Title </th>
       <td mat-cell *matCellDef="let row">{{ row.problem.title }}</td>
     </ng-container>
+
+    <!-- Tags -->
     <ng-container matColumnDef="tags">
-      <th mat-header-cell *matHeaderCellDef>Tags</th>
+      <th mat-header-cell *matHeaderCellDef> Tags </th>
       <td mat-cell *matCellDef="let row">
-        <app-tag-chip *ngFor="let t of row.problem.tags" [tag]="t"></app-tag-chip>
+        <app-tag-chip
+          *ngFor="let t of row.problem.tags; trackBy: trackByTag"
+          [tag]="t"
+        ></app-tag-chip>
       </td>
     </ng-container>
+
+    <!-- Difficulty -->
     <ng-container matColumnDef="difficulty">
-      <th mat-header-cell *matHeaderCellDef>Difficulty</th>
+      <th mat-header-cell *matHeaderCellDef> Difficulty </th>
       <td mat-cell *matCellDef="let row">
-        <app-difficulty-pill [difficulty]="row.problem.difficulty"></app-difficulty-pill>
+        <app-difficulty-pill
+          [difficulty]="row.problem.difficulty"
+        ></app-difficulty-pill>
       </td>
     </ng-container>
+
+    <!-- Due -->
     <ng-container matColumnDef="due">
-      <th mat-header-cell *matHeaderCellDef>Due</th>
-      <td mat-cell *matCellDef="let row">—</td>
+      <th mat-header-cell *matHeaderCellDef> Due </th>
+      <td mat-cell *matCellDef="let row">
+        {{ row.nextReviewAt | date: 'shortDate' }}
+      </td>
     </ng-container>
+
+    <!-- Actions -->
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let row">
         <button mat-button (click)="rate(row)">Rate</button>
       </td>
     </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    <tr
+      mat-row
+      *matRowDef="let row; columns: displayedColumns; trackBy: trackById"
+    ></tr>
+
+    <tr class="no-data" mat-row *matNoDataRow>
+      <td class="no-data-cell" [attr.colspan]="displayedColumns.length">
+        No reviews due — nice!
+      </td>
+    </tr>
   </table>
 </section>
 
-<section>
-  <h2>Due Reviews</h2>
-  <table mat-table [dataSource]="(reviews$ | async) ?? []" class="reviews-table">
+<!-- 2) UNSCORED WITH CONTROLS + SORT + PAGINATION -->
+<section class="section">
+  <h2>Unscored</h2>
+
+  <!-- Controls -->
+  <div class="controls">
+    <mat-form-field appearance="outline" class="search">
+      <mat-label>Search title</mat-label>
+      <input
+        matInput
+        type="search"
+        [value]="search"
+        (input)="onSearch($any($event.target).value)"
+        placeholder="e.g. Two Sum"
+      />
+      <button
+        *ngIf="search"
+        mat-icon-button
+        matSuffix
+        aria-label="Clear search"
+        (click)="onSearch('')"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="tags">
+      <mat-label>Filter tags</mat-label>
+      <mat-select
+        [value]="selectedTags"
+        (selectionChange)="onTagsChange($event.value)"
+        multiple
+      >
+        <mat-option *ngFor="let t of allTags" [value]="t">{{ t }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <button
+      mat-stroked-button
+      class="clear"
+      (click)="clearFilters()"
+      [disabled]="!search && selectedTags.length === 0"
+    >
+      Clear filters
+    </button>
+  </div>
+
+  <table
+    mat-table
+    [dataSource]="unscoredDS"
+    matSort
+    class="reviews-table"
+    aria-label="Unscored reviews"
+  >
+    <!-- Title -->
     <ng-container matColumnDef="title">
-      <th mat-header-cell *matHeaderCellDef>Title</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Title </th>
       <td mat-cell *matCellDef="let row">{{ row.problem.title }}</td>
     </ng-container>
+
+    <!-- Tags -->
     <ng-container matColumnDef="tags">
-      <th mat-header-cell *matHeaderCellDef>Tags</th>
+      <th mat-header-cell *matHeaderCellDef> Tags </th>
       <td mat-cell *matCellDef="let row">
-        <app-tag-chip *ngFor="let t of row.problem.tags" [tag]="t"></app-tag-chip>
+        <app-tag-chip
+          *ngFor="let t of row.problem.tags; trackBy: trackByTag"
+          [tag]="t"
+        ></app-tag-chip>
       </td>
     </ng-container>
+
+    <!-- Difficulty -->
     <ng-container matColumnDef="difficulty">
-      <th mat-header-cell *matHeaderCellDef>Difficulty</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Difficulty </th>
       <td mat-cell *matCellDef="let row">
-        <app-difficulty-pill [difficulty]="row.problem.difficulty"></app-difficulty-pill>
+        <app-difficulty-pill
+          [difficulty]="row.problem.difficulty"
+        ></app-difficulty-pill>
       </td>
     </ng-container>
+
+    <!-- Due (always — for unscored we show dash) -->
     <ng-container matColumnDef="due">
-      <th mat-header-cell *matHeaderCellDef>Due</th>
-      <td mat-cell *matCellDef="let row">{{ row.nextReviewAt | date:'shortDate' }}</td>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Due </th>
+      <td mat-cell *matCellDef>—</td>
     </ng-container>
+
+    <!-- Actions -->
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let row">
         <button mat-button (click)="rate(row)">Rate</button>
       </td>
     </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    <tr
+      mat-row
+      *matRowDef="let row; columns: displayedColumns; trackBy: trackById"
+    ></tr>
+
+    <tr class="no-data" mat-row *matNoDataRow>
+      <td class="no-data-cell" [attr.colspan]="displayedColumns.length">
+        No items match your filters.
+      </td>
+    </tr>
   </table>
+
+  <mat-paginator
+    [length]="unscoredDS?.filteredData?.length || 0"
+    [pageSize]="10"
+    [pageSizeOptions]="[5, 10, 25, 50]"
+    showFirstLastButtons
+    aria-label="Unscored paginator"
+  ></mat-paginator>
 </section>

--- a/packages/frontend/src/app/features/reviews/reviews.page.scss
+++ b/packages/frontend/src/app/features/reviews/reviews.page.scss
@@ -1,3 +1,33 @@
+.section { margin-block: 16px 28px; }
+
 .reviews-table {
   width: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.no-data .no-data-cell {
+  text-align: center;
+  padding: 16px;
+  opacity: 0.8;
+}
+
+/* Controls row */
+.controls {
+  display: grid;
+  grid-template-columns: 1fr minmax(220px, 320px) auto;
+  gap: 12px;
+  align-items: center;
+  margin: 8px 0 14px;
+
+  .search { width: 100%; }
+  .tags   { width: 100%; }
+  .clear  { white-space: nowrap; }
+}
+
+@media (max-width: 720px) {
+  .controls {
+    grid-template-columns: 1fr;
+    .clear { justify-self: start; }
+  }
 }

--- a/packages/frontend/src/app/features/reviews/reviews.page.ts
+++ b/packages/frontend/src/app/features/reviews/reviews.page.ts
@@ -1,8 +1,21 @@
-import { Component, OnInit } from '@angular/core';
-import { MatTableModule } from '@angular/material/table';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  inject,
+  AfterViewInit,
+} from '@angular/core';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDialog } from '@angular/material/dialog';
-import { AsyncPipe, NgFor } from '@angular/common';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { AsyncPipe, NgFor, DatePipe } from '@angular/common';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
+
 import { DifficultyPillComponent } from '../../shared/ui/difficulty-pill/difficulty-pill.component';
 import { TagChipComponent } from '../../shared/ui/tag-chip/tag-chip.component';
 import { ReviewsFacade } from '../../core/reviews.facade';
@@ -13,34 +26,155 @@ import { RateDialogComponent } from '../../shared/ui/rate-dialog/rate-dialog.com
 @Component({
   selector: 'app-reviews-page',
   standalone: true,
-  imports: [MatTableModule, MatButtonModule, NgFor, AsyncPipe, DifficultyPillComponent, TagChipComponent],
-  templateUrl: './reviews.page.html',
-  styleUrls: ['./reviews.page.scss']
-})
-export class ReviewsPage implements OnInit {
-  displayedColumns = ['title', 'tags', 'difficulty', 'due', 'actions'];
-  reviews$!: Observable<UiReview[]>;
-  unscored$!: Observable<UiReview[]>;
+  imports: [
+    // table + controls
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
 
-  constructor(private dialog: MatDialog, private facade: ReviewsFacade) {}
+    // buttons/icons/dialog
+    MatButtonModule,
+    MatDialogModule,
+    MatIconModule,
+
+    // utilities
+    NgFor,
+    AsyncPipe,
+    DatePipe,
+
+    // custom UI
+    DifficultyPillComponent,
+    TagChipComponent,
+  ],
+  templateUrl: './reviews.page.html',
+  styleUrls: ['./reviews.page.scss'],
+})
+export class ReviewsPage implements OnInit, AfterViewInit {
+  // Columns are shared by both tables
+  displayedColumns = ['title', 'tags', 'difficulty', 'due', 'actions'];
+
+  // Due reviews (simple async pipe usage)
+  reviews$!: Observable<UiReview[]>;
+
+  // Unscored with data source, sorting, filtering, pagination
+  unscoredDS = new MatTableDataSource<UiReview>([]);
+  allTags: string[] = [];
+  search = '';
+  selectedTags: string[] = [];
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  private dialog = inject(MatDialog);
+  private facade = inject(ReviewsFacade);
 
   ngOnInit() {
-    this.load();
+    // Load streams
+    this.reviews$ = this.facade.getDueReviews();
+
+    this.facade.getUnscored().subscribe(items => {
+      const arr = items ?? [];
+      this.unscoredDS.data = arr;
+
+      // Build tag list dynamically
+      const tagSet = new Set<string>();
+      for (const r of arr) for (const t of r.problem.tags ?? []) tagSet.add(t);
+      this.allTags = Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+
+      // Re-apply current filters
+      this.applyFilters();
+    });
+
+    // Custom predicate that considers search + tag filters
+    this.unscoredDS.filterPredicate = (row, raw) => {
+      let parsed: { search: string; tags: string[] };
+      try {
+        parsed = JSON.parse(raw || '{}');
+      } catch {
+        parsed = { search: '', tags: [] };
+      }
+      const s = (parsed.search || '').trim().toLowerCase();
+      const tags = parsed.tags || [];
+
+      const title = (row.problem?.title || '').toLowerCase();
+      const rowTags = (row.problem?.tags || []) as string[];
+
+      const matchesSearch = !s || title.includes(s);
+      const matchesTags =
+        tags.length === 0 || tags.every(t => rowTags.includes(t));
+
+      return matchesSearch && matchesTags;
+    };
   }
 
-  load() {
-    this.reviews$ = this.facade.getDueReviews();
-    this.unscored$ = this.facade.getUnscored();
+  ngAfterViewInit() {
+    // Hook paginator/sort after view init
+    this.unscoredDS.paginator = this.paginator;
+    this.unscoredDS.sort = this.sort;
+
+    // Default sort by title asc (optional)
+    setTimeout(() => {
+      if (this.sort) {
+        this.sort.active = 'title';
+        this.sort.direction = 'asc';
+        this.sort.sortChange.emit({ active: 'title', direction: 'asc' });
+      }
+    });
+  }
+
+  // Controls handlers
+  onSearch(val: string) {
+    this.search = val ?? '';
+    this.applyFilters(true);
+  }
+
+  onTagsChange(tags: string[]) {
+    this.selectedTags = tags ?? [];
+    this.applyFilters(true);
+  }
+
+  clearFilters() {
+    this.search = '';
+    this.selectedTags = [];
+    this.applyFilters(true);
+  }
+
+  private applyFilters(resetPage = false) {
+    this.unscoredDS.filter = JSON.stringify({
+      search: this.search,
+      tags: this.selectedTags,
+    });
+
+    if (resetPage && this.unscoredDS.paginator) {
+      this.unscoredDS.paginator.firstPage();
+    }
   }
 
   rate(row: UiReview) {
     const ref = this.dialog.open(RateDialogComponent, {
-      data: { title: row.problem.title }
+      data: { title: row.problem.title },
     });
     ref.afterClosed().subscribe(quality => {
       if (quality != null) {
-        this.facade.rateRecall(row.id, quality).subscribe(() => this.load());
+        this.facade.rateRecall(row.id, quality).subscribe(() => {
+          // reload streams softly; paginator & sort remain intact
+          this.reloadUnscored();
+        });
       }
     });
   }
+
+  private reloadUnscored() {
+    this.facade.getUnscored().subscribe(items => {
+      this.unscoredDS.data = items ?? [];
+      this.applyFilters();
+    });
+  }
+
+  // Perf-friendly trackBys
+  trackById = (_: number, r: UiReview) => r.id;
+  trackByTag = (_: number, t: string) => t;
 }

--- a/packages/frontend/src/app/shared/ui/app-sidenav.component.html
+++ b/packages/frontend/src/app/shared/ui/app-sidenav.component.html
@@ -1,22 +1,32 @@
-<mat-nav-list>
-  <a mat-list-item routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
-    <mat-icon matListIcon>dashboard</mat-icon>
-    <span>Dashboard</span>
+<mat-nav-list aria-label="Primary">
+  <a
+    mat-list-item
+    routerLink="/"
+    routerLinkActive="active"
+    [routerLinkActiveOptions]="{ exact: true }"
+    (click)="navigate.emit()"
+  >
+    <mat-icon matListIcon aria-hidden="true">dashboard</mat-icon>
+    <span class="label">Dashboard</span>
   </a>
-  <a mat-list-item routerLink="/reviews" routerLinkActive="active">
-    <mat-icon matListIcon>rate_review</mat-icon>
-    <span>Reviews</span>
+
+  <a mat-list-item routerLink="/reviews" routerLinkActive="active" (click)="navigate.emit()">
+    <mat-icon matListIcon aria-hidden="true">rate_review</mat-icon>
+    <span class="label">Reviews</span>
   </a>
-  <a mat-list-item routerLink="/problems" routerLinkActive="active">
-    <mat-icon matListIcon>list_alt</mat-icon>
-    <span>Problems</span>
+
+  <a mat-list-item routerLink="/problems" routerLinkActive="active" (click)="navigate.emit()">
+    <mat-icon matListIcon aria-hidden="true">list_alt</mat-icon>
+    <span class="label">Problems</span>
   </a>
-  <a mat-list-item routerLink="/lists" routerLinkActive="active">
-    <mat-icon matListIcon>playlist_add_check</mat-icon>
-    <span>Lists</span>
+
+  <a mat-list-item routerLink="/lists" routerLinkActive="active" (click)="navigate.emit()">
+    <mat-icon matListIcon aria-hidden="true">playlist_add_check</mat-icon>
+    <span class="label">Lists</span>
   </a>
-  <a mat-list-item routerLink="/sync" routerLinkActive="active">
-    <mat-icon matListIcon>sync</mat-icon>
-    <span>Sync</span>
+
+  <a mat-list-item routerLink="/sync" routerLinkActive="active" (click)="navigate.emit()">
+    <mat-icon matListIcon aria-hidden="true">sync</mat-icon>
+    <span class="label">Sync</span>
   </a>
 </mat-nav-list>

--- a/packages/frontend/src/app/shared/ui/app-sidenav.component.scss
+++ b/packages/frontend/src/app/shared/ui/app-sidenav.component.scss
@@ -1,3 +1,26 @@
-.active {
-  font-weight: bold;
+:host {
+  display: block;
+  width: 240px; /* keeps labels from wrapping */
+}
+
+mat-nav-list {
+  padding-top: 8px;
+}
+
+a.mat-mdc-list-item {
+  align-items: center;
+}
+
+.label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Active item styling (Material 3 token-friendly) */
+a.active {
+  font-weight: 600;
+  border-radius: 8px;
+  background: var(--mat-sys-secondary-container, rgba(0, 0, 0, 0.06));
+  color: var(--mat-sys-on-secondary-container, inherit);
 }

--- a/packages/frontend/src/app/shared/ui/app-sidenav.component.ts
+++ b/packages/frontend/src/app/shared/ui/app-sidenav.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterLink, RouterLinkActive } from '@angular/router';
@@ -8,6 +8,8 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
   standalone: true,
   imports: [MatListModule, MatIconModule, RouterLink, RouterLinkActive],
   templateUrl: './app-sidenav.component.html',
-  styleUrls: ['./app-sidenav.component.scss']
+  styleUrls: ['./app-sidenav.component.scss'],
 })
-export class AppSidenavComponent {}
+export class AppSidenavComponent {
+  @Output() navigate = new EventEmitter<void>();
+}

--- a/packages/frontend/src/app/shared/ui/app-toolbar.component.html
+++ b/packages/frontend/src/app/shared/ui/app-toolbar.component.html
@@ -1,17 +1,26 @@
 <mat-toolbar color="primary">
-  <button mat-icon-button (click)="menu.emit()">
-    <mat-icon>menu</mat-icon>
+  <button
+    mat-icon-button
+    (click)="menu.emit()"
+    aria-label="Open navigation"
+    matTooltip="Menu (M)"
+  >
+    <mat-icon aria-hidden="true">menu</mat-icon>
   </button>
-  <span class="title">{{ title }}</span>
+
+  <span class="title" [attr.aria-label]="title">{{ title }}</span>
   <span class="spacer"></span>
+
   <a
     mat-icon-button
     href="/api"
-    aria-label="Swagger docs"
+    aria-label="Open API docs"
     target="_blank"
     rel="noopener"
+    matTooltip="Swagger / API docs"
   >
-    <mat-icon>description</mat-icon>
+    <mat-icon aria-hidden="true">description</mat-icon>
   </a>
+
   <app-theme-toggle></app-theme-toggle>
 </mat-toolbar>

--- a/packages/frontend/src/app/shared/ui/app-toolbar.component.html
+++ b/packages/frontend/src/app/shared/ui/app-toolbar.component.html
@@ -4,5 +4,14 @@
   </button>
   <span class="title">{{ title }}</span>
   <span class="spacer"></span>
+  <a
+    mat-icon-button
+    href="/api"
+    aria-label="Swagger docs"
+    target="_blank"
+    rel="noopener"
+  >
+    <mat-icon>description</mat-icon>
+  </a>
   <app-theme-toggle></app-theme-toggle>
 </mat-toolbar>

--- a/packages/frontend/src/app/shared/ui/app-toolbar.component.scss
+++ b/packages/frontend/src/app/shared/ui/app-toolbar.component.scss
@@ -1,5 +1,21 @@
+:host {
+  display: block;
+  position: sticky;
+  top: 0;
+  z-index: 10; /* stay above content */
+}
+
+mat-toolbar {
+  /* ensure it spans full width and sticks smoothly */
+  width: 100%;
+}
+
 .title {
   margin-left: 0.5rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .spacer {

--- a/packages/frontend/src/app/shared/ui/app-toolbar.component.ts
+++ b/packages/frontend/src/app/shared/ui/app-toolbar.component.ts
@@ -1,17 +1,40 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { ThemeToggleComponent } from '../../core/theme-toggle.component';
 
 @Component({
   selector: 'app-toolbar',
   standalone: true,
-  imports: [MatToolbarModule, MatButtonModule, MatIconModule, ThemeToggleComponent],
+  imports: [MatToolbarModule, MatButtonModule, MatIconModule, MatTooltipModule, ThemeToggleComponent],
   templateUrl: './app-toolbar.component.html',
-  styleUrls: ['./app-toolbar.component.scss']
+  styleUrls: ['./app-toolbar.component.scss'],
 })
 export class AppToolbarComponent {
   @Input() title = '';
   @Output() menu = new EventEmitter<void>();
+
+  // Elevation that increases when page is scrolled
+  private scrolled = false;
+
+  @HostBinding('class')
+  get hostClasses() {
+    return `mat-elevation-z${this.scrolled ? 4 : 0}`;
+  }
+
+  @HostListener('window:scroll')
+  onScroll() {
+    const y = window.scrollY || document.documentElement.scrollTop || 0;
+    const newState = y > 2;
+    if (newState !== this.scrolled) this.scrolled = newState;
+  }
 }

--- a/packages/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.html
+++ b/packages/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.html
@@ -1,6 +1,23 @@
-<h1 mat-dialog-title>{{ data.title }}</h1>
-<div mat-dialog-content>{{ data.message }}</div>
-<div mat-dialog-actions>
-  <button mat-button (click)="cancel()">Cancel</button>
-  <button mat-raised-button color="primary" (click)="confirm()">Confirm</button>
+<h1 mat-dialog-title [class.warn]="data.type === 'warn'">
+  <mat-icon *ngIf="data.icon" class="icon" aria-hidden="true">{{ data.icon }}</mat-icon>
+  {{ data.title }}
+</h1>
+
+<div mat-dialog-content class="content" id="confirm-dialog-content">
+  {{ data.message }}
+</div>
+
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">
+    {{ data.cancelText || 'Cancel' }}
+  </button>
+
+  <button
+    mat-raised-button
+    (click)="confirm()"
+    [color]="data.type === 'warn' ? 'warn' : (data.color || 'primary')"
+    cdkFocusInitial
+  >
+    {{ data.confirmText || 'Confirm' }}
+  </button>
 </div>

--- a/packages/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.scss
+++ b/packages/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.scss
@@ -1,1 +1,18 @@
-/* dialog styles */
+:host {
+  display: block;
+  max-width: 520px; /* dialog width can also be set via open() config */
+}
+
+h1[mat-dialog-title] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &.warn .icon {
+    color: var(--mat-sys-error, #f44336);
+  }
+}
+
+.content {
+  white-space: pre-wrap; /* keep \n line breaks readable */
+}

--- a/packages/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.ts
+++ b/packages/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.ts
@@ -1,28 +1,32 @@
 import { Component, inject } from '@angular/core';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 export interface ConfirmDialogData {
   title: string;
   message: string;
+  /** Button texts (optional) */
+  confirmText?: string;
+  cancelText?: string;
+  /** Color / intent */
+  type?: 'warn' | 'primary';
+  color?: 'primary' | 'accent' | 'warn';
+  /** Optional icon name (e.g., 'warning', 'info', 'delete') */
+  icon?: string;
 }
 
 @Component({
   selector: 'app-confirm-dialog',
   standalone: true,
-  imports: [MatDialogModule, MatButtonModule],
+  imports: [MatDialogModule, MatButtonModule, MatIconModule],
   templateUrl: './confirm-dialog.component.html',
-  styleUrls: ['./confirm-dialog.component.scss']
+  styleUrls: ['./confirm-dialog.component.scss'],
 })
 export class ConfirmDialogComponent {
-  private dialogRef = inject(MatDialogRef<ConfirmDialogComponent>);
+  private dialogRef = inject(MatDialogRef<ConfirmDialogComponent, boolean>);
   readonly data = inject<ConfirmDialogData>(MAT_DIALOG_DATA);
 
-  cancel() {
-    this.dialogRef.close(false);
-  }
-
-  confirm() {
-    this.dialogRef.close(true);
-  }
+  cancel()  { this.dialogRef.close(false); }
+  confirm() { this.dialogRef.close(true); }
 }

--- a/packages/frontend/src/app/shared/ui/difficulty-pill/difficulty-pill.component.html
+++ b/packages/frontend/src/app/shared/ui/difficulty-pill/difficulty-pill.component.html
@@ -1,1 +1,7 @@
-<mat-chip [ngClass]="difficulty.toLowerCase()">{{ difficulty }}</mat-chip>
+<mat-chip
+  class="pill"
+  [ngClass]="cssClass"
+  [attr.aria-label]="'Difficulty: ' + label"
+>
+  {{ label }}
+</mat-chip>

--- a/packages/frontend/src/app/shared/ui/difficulty-pill/difficulty-pill.component.scss
+++ b/packages/frontend/src/app/shared/ui/difficulty-pill/difficulty-pill.component.scss
@@ -1,9 +1,33 @@
+:host { display: inline-block; }
+
+/* Base pill tweaks */
+.pill {
+  font-weight: 600;
+  text-transform: capitalize;
+  border-radius: 999px;
+  padding-inline: 10px;
+  line-height: 28px; /* compact, readable */
+}
+
+/* Map to Material 3 tokens so it’s theme-aware */
 .easy {
-  background: #c8e6c9;
+  background: var(--mat-sys-tertiary-container, #c8e6c9);
+  color: var(--mat-sys-on-tertiary-container, #0b3d1b);
 }
 .medium {
-  background: #ffe0b2;
+  background: var(--mat-sys-secondary-container, #ffe0b2);
+  color: var(--mat-sys-on-secondary-container, #3a2500);
 }
 .hard {
-  background: #ffcdd2;
+  background: var(--mat-sys-error-container, #ffcdd2);
+  color: var(--mat-sys-on-error-container, #410002);
+}
+.unknown {
+  background: var(--mat-sys-surface-variant, #e0e0e0);
+  color: var(--mat-sys-on-surface-variant, #222);
+}
+
+/* Optional: subtle border for extra contrast (works in dark/light) */
+.pill {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 20%, transparent);
 }

--- a/packages/frontend/src/app/shared/ui/difficulty-pill/difficulty-pill.component.ts
+++ b/packages/frontend/src/app/shared/ui/difficulty-pill/difficulty-pill.component.ts
@@ -2,13 +2,26 @@ import { Component, Input } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { MatChipsModule } from '@angular/material/chips';
 
+type DifficultyLevel = 'Easy' | 'Medium' | 'Hard';
+type CssClass = 'easy' | 'medium' | 'hard' | 'unknown';
+
 @Component({
   selector: 'app-difficulty-pill',
   standalone: true,
   imports: [MatChipsModule, NgClass],
   templateUrl: './difficulty-pill.component.html',
-  styleUrls: ['./difficulty-pill.component.scss']
+  styleUrls: ['./difficulty-pill.component.scss'],
 })
 export class DifficultyPillComponent {
-  @Input() difficulty: 'Easy' | 'Medium' | 'Hard' | string = 'Easy';
+  /** Accepts 'Easy' | 'Medium' | 'Hard' (any casing). Falls back to 'Unknown'. */
+  @Input() set difficulty(value: string | DifficultyLevel) {
+    const v = (value ?? '').toString().trim().toLowerCase();
+    if (v === 'easy')       { this.cssClass = 'easy';   this.label = 'Easy'; }
+    else if (v === 'medium'){ this.cssClass = 'medium'; this.label = 'Medium'; }
+    else if (v === 'hard')  { this.cssClass = 'hard';   this.label = 'Hard'; }
+    else { this.cssClass = 'unknown'; this.label = (value as any) || 'Unknown'; }
+  }
+
+  label = 'Easy';
+  cssClass: CssClass = 'easy';
 }

--- a/packages/frontend/src/app/shared/ui/rate-dialog/rate-dialog.component.html
+++ b/packages/frontend/src/app/shared/ui/rate-dialog/rate-dialog.component.html
@@ -1,7 +1,26 @@
-<h1 mat-dialog-title>{{ data.title }}</h1>
-<div mat-dialog-content>
+<h1 mat-dialog-title>Rate recall — {{ data.title }}</h1>
+
+<div mat-dialog-content class="content">
   <p>Select recall quality:</p>
+
+  <div class="grid">
+    <button
+      *ngFor="let q of defs"
+      mat-raised-button
+      [color]="q.color"
+      (click)="choose(q.value)"
+      [matTooltip]="q.help"
+      [attr.aria-label]="q.aria"
+    >
+      <mat-icon class="icon" aria-hidden="true" *ngIf="q.icon">{{ q.icon }}</mat-icon>
+      <span class="value">{{ q.value }}</span>
+      <span class="label">{{ q.label }}</span>
+    </button>
+  </div>
+
+  <p class="hint">Tip: press 0–5 on your keyboard.</p>
 </div>
-<div mat-dialog-actions>
-  <button mat-button *ngFor="let q of qualities" (click)="choose(q)">{{ q }}</button>
+
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
 </div>

--- a/packages/frontend/src/app/shared/ui/rate-dialog/rate-dialog.component.scss
+++ b/packages/frontend/src/app/shared/ui/rate-dialog/rate-dialog.component.scss
@@ -1,1 +1,19 @@
-/* empty */
+.content { display: grid; gap: 12px; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+button[mat-raised-button] {
+  justify-content: flex-start;
+  gap: 8px;
+  text-transform: none;
+}
+
+.icon { opacity: 0.9; }
+.value { font-weight: 700; width: 1.5rem; text-align: center; }
+.label { opacity: 0.9; }
+
+.hint { opacity: 0.75; margin: 4px 2px 0; font-size: 0.85rem; }

--- a/packages/frontend/src/app/shared/ui/rate-dialog/rate-dialog.component.ts
+++ b/packages/frontend/src/app/shared/ui/rate-dialog/rate-dialog.component.ts
@@ -1,21 +1,40 @@
-import { Component, inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Component, HostListener, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { NgFor } from '@angular/common';
+
+type BtnColor = 'primary' | 'accent' | 'warn';
 
 @Component({
   selector: 'app-rate-dialog',
   standalone: true,
-  imports: [MatButtonModule, NgFor],
+  imports: [MatDialogModule, MatButtonModule, MatIconModule, MatTooltipModule, NgFor],
   templateUrl: './rate-dialog.component.html',
-  styleUrls: ['./rate-dialog.component.scss']
+  styleUrls: ['./rate-dialog.component.scss'],
 })
 export class RateDialogComponent {
-  qualities = [0, 1, 2, 3, 4, 5];
-  private ref = inject(MatDialogRef<RateDialogComponent>);
-  data = inject<{ title: string }>(MAT_DIALOG_DATA);
+  private ref = inject(MatDialogRef<RateDialogComponent, number | null>);
+  readonly data = inject<{ title: string }>(MAT_DIALOG_DATA);
 
-  choose(q: number) {
-    this.ref.close(q);
+  // SM-2 style meanings with sensible colors
+  defs = [
+    { value: 0, label: 'Blackout',   help: 'Complete failure to recall',          color: 'warn'   as BtnColor, icon: 'block' },
+    { value: 1, label: 'Incorrect',  help: 'Incorrect or major gaps',             color: 'warn'   as BtnColor, icon: 'close' },
+    { value: 2, label: 'Hard',       help: 'Barely recalled; heavy effort',       color: 'warn'   as BtnColor, icon: 'priority_high' },
+    { value: 3, label: 'Okay',       help: 'Hesitant, partially correct',         color: 'accent' as BtnColor, icon: 'check_circle_outline' },
+    { value: 4, label: 'Good',       help: 'Correct with minor hesitation',       color: 'accent' as BtnColor, icon: 'check' },
+    { value: 5, label: 'Easy',       help: 'Perfect, immediate recall',           color: 'primary'as BtnColor, icon: 'task_alt' },
+  ];
+
+  choose(q: number) { this.ref.close(q); }
+  cancel() { this.ref.close(null); }
+
+  // Keyboard shortcuts: 0–5 choose; Esc cancels
+  @HostListener('document:keydown', ['$event'])
+  onKey(e: KeyboardEvent) {
+    if (e.key >= '0' && e.key <= '5') { this.choose(Number(e.key)); }
+    else if (e.key === 'Escape') { this.cancel(); }
   }
 }

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -1,11 +1,62 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>LeetCode Revision Tracker</title>
-  <base href="/">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>LeetCode Revision Tracker</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- Optional: browser UI color (updates after app starts) -->
+    <meta name="theme-color" content="#121212" />
+
+    <!-- Material Icons (ligatures for <mat-icon>home</mat-icon>) -->
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+
+    <!-- Pre-apply theme classes BEFORE Angular bootstraps -->
+    <script>
+      (function () {
+        try {
+          var saved = localStorage.getItem('theme');
+          var useDark = saved
+            ? saved === 'high-contrast-dark'
+            : window.matchMedia &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+          var cls = useDark
+            ? ['theme-high-contrast-dark', 'vscode-hc']
+            : ['theme-white'];
+
+          // Apply to <html> immediately (no layout shift)
+          document.documentElement.classList.add.apply(
+            document.documentElement.classList,
+            cls
+          );
+
+          // Apply to <body> as soon as it exists
+          document.addEventListener('DOMContentLoaded', function () {
+            document.body.classList.add.apply(document.body.classList, cls);
+          });
+
+          // Prevent white flash in dark mode
+          if (useDark) {
+            var s = document.createElement('style');
+            s.textContent = 'body{background:#1e1e1e;color-scheme:dark}';
+            document.head.appendChild(s);
+          } else {
+            var s2 = document.createElement('style');
+            s2.textContent = 'body{color-scheme:light}';
+            document.head.appendChild(s2);
+          }
+        } catch (e) {
+          /* noop */
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
 </html>

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -1,6 +1,336 @@
+/* styles.scss */
 @use '@angular/material' as mat;
-@use './styles/theme';
+
+/* Keep vscode-hc overrides, but they MUST be scoped in that file (e.g. .vscode-hc { ... }) */
+@import './themes/vscode-hc';
 
 @include mat.core();
 
-body { margin: 0; font-family: Roboto, sans-serif; }
+/* ---------- Light (white) ---------- */
+$white-primary: mat.define-palette(mat.$indigo-palette);
+$white-accent:  mat.define-palette(mat.$pink-palette);
+$white-warn:    mat.define-palette(mat.$red-palette);
+
+$white-theme: mat.define-light-theme((
+  color: (
+    primary: $white-primary,
+    accent:  $white-accent,
+    warn:    $white-warn,
+  ),
+  density: 0,
+));
+
+/* ---------- Dark (high-contrast) ---------- */
+$dark-primary: mat.define-palette(mat.$blue-palette);
+$dark-accent:  mat.define-palette(mat.$blue-grey-palette);
+$dark-warn:    mat.define-palette(mat.$red-palette);
+
+$high-contrast-dark-theme: mat.define-dark-theme((
+  color: (
+    primary: $dark-primary,
+    accent:  $dark-accent,
+    warn:    $dark-warn,
+  ),
+  density: 0,
+));
+
+/* ---------- E-Ink (pure black/white) ---------- */
+$eink-primary: mat.define-palette(mat.$grey-palette, 900);
+$eink-accent:  mat.define-palette(mat.$grey-palette, 900);
+$eink-warn:    mat.define-palette(mat.$grey-palette, 900);
+
+$eink-theme: mat.define-light-theme((
+  color: (
+    primary: $eink-primary,
+    accent:  $eink-accent,
+    warn:    $eink-warn,
+  ),
+  density: -1,
+));
+
+/* ---------- E-Ink DARK (inverted pure B/W) ---------- */
+$eink-dark-primary: mat.define-palette(mat.$grey-palette, 50);
+$eink-dark-theme: mat.define-dark-theme((
+  color: (
+    primary: $eink-dark-primary,
+    accent:  $eink-dark-primary,
+    warn:    $eink-dark-primary,
+  ),
+  density: -1,
+));
+
+/* ---------- Apply component themes under body classes ---------- */
+.theme-white               { @include mat.all-component-themes($white-theme); }
+.theme-high-contrast-dark  { @include mat.all-component-themes($high-contrast-dark-theme); }
+.theme-eink                { @include mat.all-component-themes($eink-theme); }
+.theme-eink-dark           { @include mat.all-component-themes($eink-dark-theme); }
+
+/* Typography only once */
+:root { @include mat.all-component-typographies($white-theme); }
+
+/* Native controls color-scheme */
+:root { color-scheme: light; }
+.theme-high-contrast-dark,
+.theme-eink-dark { color-scheme: dark; }
+
+/* ---------- App background & layout ---------- */
+html, body, app-root { min-height: 100%; }
+
+body.theme-white,
+body.theme-eink { background: #fff; }
+
+body.theme-high-contrast-dark,
+body.theme-eink-dark { background: #000; }
+
+/* ---------- COMMON: widen main content & tables (no phone-like column) ---------- */
+.content { max-width: none; width: 100%; margin: 0; padding: 16px; }
+.mat-mdc-table { width: 100%; margin: 0; table-layout: auto; }
+.mat-mdc-cell, .mat-mdc-header-cell { padding: 12px 16px; }
+
+/* If you wrap your main content with .mat-app-background, keep it readable */
+.mat-app-background { min-height: 100%; }
+
+/* ============================================================= */
+/* ======================= E-INK LIGHT ========================= */
+/* ============================================================= */
+.theme-eink {
+  /* Monochrome tokens for MDC-driven bits */
+  --mat-sys-surface: #ffffff;
+  --mat-sys-on-surface: #000000;
+  --mat-sys-primary: #000000;
+  --mat-sys-on-primary: #ffffff;
+  --mat-sys-surface-variant: #f4f4f4;
+  --mat-sys-on-surface-variant: #000000;
+  --mat-sys-outline: #000000;
+
+  body { background: #fff; color: #000; font-family: Georgia, 'Times New Roman', Times, serif; }
+
+  /* Sidenav as index column */
+  mat-sidenav {
+    background: #fff !important;
+    color: #000 !important;
+    border-right: 1px solid #000;
+    width: 260px !important;
+  }
+
+  /* Nav item text/icon must stay visible when selected */
+  a.mat-mdc-list-item {
+    color: #000 !important;
+    border-left: 3px solid transparent;
+
+    .mat-mdc-list-item-title,
+    .mat-mdc-list-item-line,
+    .mat-mdc-list-item-unscoped-content,
+    .mdc-list-item__primary-text,
+    mat-icon { color: inherit !important; }
+  }
+  a.mat-mdc-list-item:hover {
+    background: #000 !important;
+    color: #fff !important;
+  }
+  a.mat-mdc-list-item.active {
+    background: #000 !important;
+    color: #fff !important;
+    border-left-color: #000;
+  }
+
+  /* Toolbar & cards: paper-like, no elevation */
+  mat-toolbar {
+    background: #fff !important;
+    color: #000 !important;
+    border-bottom: 1px solid #000;
+  }
+  .mat-mdc-card, mat-card.mdc-card {
+    background: #fff !important; color: #000 !important;
+    border: 1px solid #000; border-radius: 0; box-shadow: none !important;
+  }
+
+  /* Buttons: only black/white */
+  .mat-mdc-button-base { border-radius: 0; box-shadow: none !important; }
+  .mat-mdc-raised-button, .mat-mdc-unelevated-button { background: #000 !important; color: #fff !important; }
+  .mat-mdc-outlined-button, .mat-mdc-stroked-button { border-color: #000 !important; color: #000 !important; }
+  .mat-mdc-icon-button { color: #000 !important; }
+
+  /* Inputs (outlined) – fix label/input/placeholder/caret visibility */
+  .mdc-text-field--outlined {
+    background: #fff !important; color: #000 !important; border-radius: 0 !important;
+
+    --mdc-outlined-text-field-outline-color: #000;
+    --mdc-outlined-text-field-hover-outline-color: #000;
+    --mdc-outlined-text-field-focus-outline-color: #000;
+
+    --mdc-outlined-text-field-input-text-color: #000;
+    --mdc-outlined-text-field-label-text-color: #000;
+    --mdc-outlined-text-field-caret-color: #000;
+    --mdc-outlined-text-field-input-text-placeholder-color: #333;
+  }
+  .mat-mdc-form-field-subscript-wrapper { color: #000; }
+
+  /* Select / option panel contrast */
+  .mat-mdc-select-panel { background: #fff !important; color: #000 !important; }
+  .mat-mdc-option.mdc-list-item--selected,
+  .mat-mdc-option:hover { background: #000 !important; color: #fff !important; }
+
+  /* Tables: crisp grid */
+  .mat-mdc-table { background: #fff; color: #000; border: 1px solid #000; border-radius: 0; }
+  .mat-mdc-header-row, .mat-mdc-row { border-bottom: 1px solid #000; }
+
+  /* Chips/pills: outlined only */
+  .mat-mdc-chip { background: transparent !important; border: 1px solid #000; color: #000; border-radius: 999px; }
+
+  /* Remove ripples & shadows */
+  .mat-ripple-element { display: none !important; }
+  [class*='mat-elevation-z'] { box-shadow: none !important; }
+}
+
+/* ============================================================= */
+/* ====================== E-INK DARK =========================== */
+/* ============================================================= */
+.theme-eink-dark {
+  --mat-sys-surface: #000000;
+  --mat-sys-on-surface: #ffffff;
+  --mat-sys-primary: #ffffff;
+  --mat-sys-on-primary: #000000;
+  --mat-sys-surface-variant: #1a1a1a;
+  --mat-sys-on-surface-variant: #ffffff;
+  --mat-sys-outline: #ffffff;
+
+  body { background: #000; color: #fff; font-family: Georgia, 'Times New Roman', Times, serif; }
+
+  .content { max-width: none; width: 100%; margin: 0; padding: 16px; }
+  .mat-mdc-table { width: 100%; margin: 0; table-layout: auto; }
+  .mat-mdc-cell, .mat-mdc-header-cell { padding: 12px 16px; }
+
+  mat-sidenav {
+    background: #000 !important;
+    color: #fff !important;
+    border-right: 1px solid #fff;
+    width: 260px !important;
+  }
+
+  a.mat-mdc-list-item {
+    color: #fff !important;
+    border-left: 3px solid transparent;
+
+    .mat-mdc-list-item-title,
+    .mat-mdc-list-item-line,
+    .mat-mdc-list-item-unscoped-content,
+    .mdc-list-item__primary-text,
+    mat-icon { color: inherit !important; }
+  }
+  a.mat-mdc-list-item:hover {
+    background: #fff !important; color: #000 !important;
+  }
+  a.mat-mdc-list-item.active {
+    background: #fff !important; color: #000 !important; border-left-color: #fff;
+  }
+
+  mat-toolbar { background: #000 !important; color: #fff !important; border-bottom: 1px solid #fff; }
+  .mat-mdc-card, mat-card.mdc-card {
+    background: #000 !important; color: #fff !important;
+    border: 1px solid #fff; border-radius: 0; box-shadow: none !important;
+  }
+
+  .mat-mdc-button-base { border-radius: 0; box-shadow: none !important; }
+  .mat-mdc-raised-button, .mat-mdc-unelevated-button { background: #fff !important; color: #000 !important; }
+  .mat-mdc-outlined-button, .mat-mdc-stroked-button { border-color: #fff !important; color: #fff !important; }
+  .mat-mdc-icon-button { color: #fff !important; }
+
+  .mdc-text-field--outlined {
+    background: #000 !important; color: #fff !important; border-radius: 0 !important;
+
+    --mdc-outlined-text-field-outline-color: #fff;
+    --mdc-outlined-text-field-hover-outline-color: #fff;
+    --mdc-outlined-text-field-focus-outline-color: #fff;
+
+    --mdc-outlined-text-field-input-text-color: #fff;
+    --mdc-outlined-text-field-label-text-color: #fff;
+    --mdc-outlined-text-field-caret-color: #fff;
+    --mdc-outlined-text-field-input-text-placeholder-color: #bbb;
+  }
+  .mat-mdc-form-field-subscript-wrapper { color: #fff; }
+
+  .mat-mdc-select-panel { background: #000 !important; color: #fff !important; }
+  .mat-mdc-option.mdc-list-item--selected,
+  .mat-mdc-option:hover { background: #fff !important; color: #000 !important; }
+
+  .mat-mdc-table { background: #000; color: #fff; border: 1px solid #fff; border-radius: 0; }
+  .mat-mdc-header-row, .mat-mdc-row { border-bottom: 1px solid #fff; }
+
+  .mat-mdc-chip { background: transparent !important; border: 1px solid #fff; color: #fff; border-radius: 999px; }
+
+  .mat-ripple-element { display: none !important; }
+  [class*='mat-elevation-z'] { box-shadow: none !important; }
+}
+
+
+
+/* ==== Layout guardrails: paste at the END of styles.scss ==== */
+
+/* 1) Make layout sizing predictable */
+*, *::before, *::after { box-sizing: border-box; }
+
+/* 2) Kill page-wide horizontal scroll without hiding legit inner scrolls */
+html, body { max-width: 100%; overflow-x: clip; } /* clip > hidden (perf) */
+
+/* 3) Content container: tidy inset + max width */
+:root { --page-max: 1200px; } /* tweak to taste */
+.content {
+  max-width: min(var(--page-max), 100%);
+  margin-inline: auto;
+  padding-left: max(16px, env(safe-area-inset-left));
+  padding-right: max(16px, env(safe-area-inset-right));
+}
+
+/* 4) Sidenav container/content shouldn’t create stray scrollbars */
+mat-sidenav-container,
+mat-sidenav-content { overflow-x: clip; }
+
+/* 5) Tables: never push the page; scroll inside if needed */
+table.mat-mdc-table {
+  display: block;        /* make it a scroll container */
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* 6) Cells: allow wrapping so long strings/chips don’t force overflow */
+.mat-mdc-header-cell,
+.mat-mdc-cell {
+  white-space: normal !important;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  padding: 12px 16px;
+}
+
+/* 7) Tag chips: allow natural wrapping and spacing in table cells */
+td app-tag-chip { margin: 2px 6px 2px 0; display: inline-block; }
+
+/* 8) Inputs/selects: ensure text & labels are visible in E-Ink themes */
+.theme-eink .mdc-text-field--outlined,
+.theme-eink-dark .mdc-text-field--outlined {
+  --mdc-outlined-text-field-input-text-color: var(--mat-sys-on-surface, #000);
+  --mdc-outlined-text-field-label-text-color: var(--mat-sys-on-surface, #000);
+  --mdc-outlined-text-field-caret-color: var(--mat-sys-on-surface, #000);
+  --mdc-outlined-text-field-input-text-placeholder-color: rgba(0,0,0,.6);
+}
+.theme-eink-dark .mdc-text-field--outlined {
+  --mdc-outlined-text-field-input-text-color: #fff;
+  --mdc-outlined-text-field-label-text-color: #fff;
+  --mdc-outlined-text-field-caret-color: #fff;
+  --mdc-outlined-text-field-input-text-placeholder-color: rgba(255,255,255,.7);
+}
+
+/* 9) Selected nav item: keep text/icons readable in E-Ink */
+.theme-eink a.mat-mdc-list-item.active,
+.theme-eink a.mat-mdc-list-item:hover {
+  background: #000 !important; color: #fff !important;
+}
+.theme-eink-dark a.mat-mdc-list-item.active,
+.theme-eink-dark a.mat-mdc-list-item:hover {
+  background: #fff !important; color: #000 !important;
+}
+.theme-eink a.mat-mdc-list-item,
+.theme-eink-dark a.mat-mdc-list-item {
+  color: inherit !important;
+}

--- a/packages/frontend/src/styles/_theme.scss
+++ b/packages/frontend/src/styles/_theme.scss
@@ -1,29 +1,34 @@
 @use '@angular/material' as mat;
 
+@include mat.core();
+
+/* define themes */
 $white-primary: mat.define-palette(mat.$indigo-palette);
-$white-accent: mat.define-palette(mat.$pink-palette);
+$white-accent:  mat.define-palette(mat.$pink-palette);
 $white-theme: mat.define-light-theme((
-  color: (
-    primary: $white-primary,
-    accent: $white-accent,
-  ),
+  color: (primary: $white-primary, accent: $white-accent),
   density: 0,
 ));
 
 $dark-primary: mat.define-palette(mat.$blue-palette);
-$dark-accent: mat.define-palette(mat.$blue-grey-palette);
+$dark-accent:  mat.define-palette(mat.$blue-grey-palette);
 $high-contrast-dark-theme: mat.define-dark-theme((
-  color: (
-    primary: $dark-primary,
-    accent: $dark-accent,
-  ),
+  color: (primary: $dark-primary, accent: $dark-accent),
   density: 0,
 ));
 
+/* GLOBAL DEFAULT = HIGH CONTRAST DARK */
+:root {
+  @include mat.all-component-themes($high-contrast-dark-theme);
+  @include mat.all-component-typographies($white-theme); /* typography once */
+}
+
+/* Optional: allow toggling to LIGHT by adding .theme-white to <body> */
 .theme-white {
   @include mat.all-component-themes($white-theme);
 }
 
-.theme-high-contrast-dark {
-  @include mat.all-component-themes($high-contrast-dark-theme);
-}
+/* Native widgets + surfaces */
+:root { color-scheme: dark; }
+html, body, app-root { min-height: 100%; }
+body { background: #121212; } /* dark surface baseline */

--- a/packages/frontend/src/themes/_vscode-hc.scss
+++ b/packages/frontend/src/themes/_vscode-hc.scss
@@ -1,0 +1,124 @@
+/* VS Code–style High Contrast skin (scoped) */
+.vscode-hc {
+  /* --- Core palette (VS Code vibes) --- */
+  --vscode-bg:        #1e1e1e;  /* editor */
+  --vscode-surface:   #252526;  /* sidebar/drawer */
+  --vscode-header:    #3c3c3c;  /* titlebar/toolbar */
+  --vscode-border:    #3c3c3c;
+  --vscode-hover:     #2a2d2e;
+  --vscode-active:    #37373d;
+  --vscode-primary:   #0e639c;  /* VS Code blue */
+  --vscode-focus:     #007acc;  /* outline */
+  --vscode-warn:      #cca700;
+  --vscode-error:     #f48771;
+  --vscode-ok:        #89d185;
+  --vscode-text:      #e6e6e6;
+  --vscode-dim:       #b3b3b3;
+
+  /* Backgrounds */
+  body { background: var(--vscode-bg); color: var(--vscode-text); }
+
+  /* Toolbar / header */
+  app-toolbar, mat-toolbar.mdc-top-app-bar, mat-toolbar {
+    background: var(--vscode-header) !important;
+    color: var(--vscode-text) !important;
+    border-bottom: 1px solid var(--vscode-border);
+  }
+
+  /* Sidenav / nav list */
+  mat-sidenav {
+    background: var(--vscode-surface) !important;
+    color: var(--vscode-text);
+    border-right: 1px solid var(--vscode-border);
+  }
+  mat-nav-list { padding-top: 4px; }
+  a.mat-mdc-list-item {
+    color: var(--vscode-text);
+    border-left: 3px solid transparent;
+    &:hover { background: var(--vscode-hover); }
+    &.active {
+      background: var(--vscode-active);
+      border-left-color: var(--vscode-primary);
+      font-weight: 600;
+    }
+  }
+  mat-icon { color: var(--vscode-dim); }
+
+  /* Cards / panels */
+  mat-card.mdc-card, .mat-mdc-card {
+    background: var(--vscode-bg);
+    color: var(--vscode-text);
+    border: 1px solid var(--vscode-border);
+    border-radius: 10px;
+  }
+  .mat-mdc-card-header { padding: 12px 16px; }
+
+  /* Buttons */
+  .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-fab, .mat-mdc-mini-fab {
+    background: var(--vscode-primary) !important;
+    color: #fff !important;
+  }
+  .mat-mdc-outlined-button {
+    border-color: var(--vscode-border) !important;
+    color: var(--vscode-text) !important;
+  }
+  .mat-mdc-button:not(.mat-mdc-unelevated-button):not(.mat-mdc-raised-button) {
+    color: var(--vscode-primary);
+  }
+
+  /* Inputs / form fields */
+  .mat-mdc-form-field-subscript-wrapper { color: var(--vscode-dim); }
+  .mdc-text-field--filled {
+    background: var(--vscode-bg) !important;
+  }
+  .mdc-text-field, .mdc-text-field--outlined {
+    color: var(--vscode-text);
+    --mdc-outlined-text-field-outline-color: var(--vscode-border);
+    --mdc-outlined-text-field-hover-outline-color: var(--vscode-text);
+    --mdc-outlined-text-field-focus-outline-color: var(--vscode-primary);
+  }
+
+  /* Tables */
+  .mat-mdc-table {
+    background: var(--vscode-bg);
+    color: var(--vscode-text);
+    border: 1px solid var(--vscode-border);
+  }
+  .mat-mdc-header-row, .mat-mdc-row {
+    border-bottom: 1px solid var(--vscode-border);
+  }
+  .mat-mdc-row:hover { background: var(--vscode-hover); }
+
+  /* Chips / badges */
+  .mat-mdc-chip {
+    background: var(--vscode-active) !important;
+    color: var(--vscode-text) !important;
+    border: 1px solid var(--vscode-border);
+  }
+
+  /* Paginator / toolbars in content */
+  .mat-mdc-paginator, .mat-mdc-toolbar {
+    background: var(--vscode-header);
+    color: var(--vscode-text);
+    border-top: 1px solid var(--vscode-border);
+    border-bottom: 1px solid var(--vscode-border);
+  }
+
+  /* Focus visibility: strong high-contrast ring */
+  :focus-visible {
+    outline: 2px solid var(--vscode-focus) !important;
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  /* Scrollbar (WebKit-based browsers) */
+  *::-webkit-scrollbar        { width: 12px; height: 12px; }
+  *::-webkit-scrollbar-track  { background: var(--vscode-bg); }
+  *::-webkit-scrollbar-thumb  { background: #454545; border-radius: 8px; border: 2px solid var(--vscode-bg); }
+  *::-webkit-scrollbar-thumb:hover { background: #5a5a5a; }
+
+  /* Density (slightly tighter like editors) */
+  .mat-mdc-form-field, .mat-mdc-button-base, .mat-mdc-list-item {
+    --mdc-typography-button-letter-spacing: .02em;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,7 +160,7 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/cdk@17":
+"@angular/cdk@^17.3.0":
   version "17.3.10"
   resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-17.3.10.tgz#4a3bab529cd65bb19cb89c89b3548dcc534d1a44"
   integrity sha512-b1qktT2c1TTTe5nTji/kFAVW92fULK0YhYAvJ+BjZTPKu2FniZNe8o4qqQ0pUuvtMu+ZQxp/QqFYoidIVCjScg==
@@ -169,7 +169,7 @@
   optionalDependencies:
     parse5 "^7.1.2"
 
-"@angular/cli@17":
+"@angular/cli@^17.3.0":
   version "17.3.17"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-17.3.17.tgz#15464e29db9a806b52d7574f46d1deb705838fbd"
   integrity sha512-FgOvf9q5d23Cpa7cjP1FYti/v8S1FTm8DEkW3TY8lkkoxh3isu28GFKcLD1p/XF3yqfPkPVHToOFla5QwsEgBQ==
@@ -200,7 +200,7 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/compiler-cli@17":
+"@angular/compiler-cli@^17.3.0":
   version "17.3.12"
   resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-17.3.12.tgz#d54a65383ea56bdaf474af3ae475cc1585b11a0b"
   integrity sha512-1F8M7nWfChzurb7obbvuE7mJXlHtY1UG58pcwcomVtpPb+kPavgAO8OEvJHYBMV+bzSxkXt5UIwL9lt9jHUxZA==
@@ -214,28 +214,28 @@
     tslib "^2.3.0"
     yargs "^17.2.1"
 
-"@angular/compiler@17":
+"@angular/compiler@^17.3.0":
   version "17.3.12"
   resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-17.3.12.tgz#c7f855deb67f05023d53358f6dcc8803c1c90efa"
   integrity sha512-vwI8oOL/gM+wPnptOVeBbMfZYwzRxQsovojZf+Zol9szl0k3SZ3FycWlxxXZGFu3VIEfrP6pXplTmyODS/Lt1w==
   dependencies:
     tslib "^2.3.0"
 
-"@angular/core@17":
+"@angular/core@^17.3.0":
   version "17.3.12"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-17.3.12.tgz#d66ee14071c9f157f68907cff461f235e6eaffe1"
   integrity sha512-MuFt5yKi161JmauUta4Dh0m8ofwoq6Ino+KoOtkYMBGsSx+A7dSm+DUxxNwdj7+DNyg3LjVGCFgBFnq4g8z06A==
   dependencies:
     tslib "^2.3.0"
 
-"@angular/forms@17":
+"@angular/forms@^17.3.0":
   version "17.3.12"
   resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-17.3.12.tgz#09ffd2d09822bd4e0d1c2eada7d0bed959b47042"
   integrity sha512-tV6r12Q3yEUlXwpVko4E+XscunTIpPkLbaiDn/MTL3Vxi2LZnsLgHyd/i38HaHN+e/H3B0a1ToSOhV5wf3ay4Q==
   dependencies:
     tslib "^2.3.0"
 
-"@angular/material@17":
+"@angular/material@^17.3.0":
   version "17.3.10"
   resolved "https://registry.yarnpkg.com/@angular/material/-/material-17.3.10.tgz#db4c41bcc4ba6a6328be3d89dc95947a48555b54"
   integrity sha512-hHMQES0tQPH5JW33W+mpBPuM8ybsloDTqFPuRV8cboDjosAWfJhzAKF3ozICpNlUrs62La/2Wu/756GcQrxebg==
@@ -2620,6 +2620,11 @@
     "@material/theme" "15.0.0-canary.7f224ddd4.0"
     tslib "^2.1.0"
 
+"@nestjs/axios@^9.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-4.0.0.tgz#520ff7c6238e635658fe334ee62db9d1b9c5546f"
+  integrity sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==
+
 "@nestjs/cli@^9.0.0":
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-9.5.0.tgz#ddf1b0e21b5507c151e0cd1a4cfcf6c55df7cb2e"
@@ -2864,6 +2869,95 @@
   integrity sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==
   dependencies:
     "@noble/hashes" "^1.1.5"
+
+"@parcel/watcher-android-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz#507f836d7e2042f798c7d07ad19c3546f9848ac1"
+  integrity sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==
+
+"@parcel/watcher-darwin-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz#3d26dce38de6590ef79c47ec2c55793c06ad4f67"
+  integrity sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==
+
+"@parcel/watcher-darwin-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz#99f3af3869069ccf774e4ddfccf7e64fd2311ef8"
+  integrity sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==
+
+"@parcel/watcher-freebsd-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz#14d6857741a9f51dfe51d5b08b7c8afdbc73ad9b"
+  integrity sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==
+
+"@parcel/watcher-linux-arm-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz#43c3246d6892381db473bb4f663229ad20b609a1"
+  integrity sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==
+
+"@parcel/watcher-linux-arm-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz#663750f7090bb6278d2210de643eb8a3f780d08e"
+  integrity sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==
+
+"@parcel/watcher-linux-arm64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz#ba60e1f56977f7e47cd7e31ad65d15fdcbd07e30"
+  integrity sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==
+
+"@parcel/watcher-linux-arm64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz#f7fbcdff2f04c526f96eac01f97419a6a99855d2"
+  integrity sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==
+
+"@parcel/watcher-linux-x64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz#4d2ea0f633eb1917d83d483392ce6181b6a92e4e"
+  integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
+
+"@parcel/watcher-linux-x64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz#277b346b05db54f55657301dd77bdf99d63606ee"
+  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
+
+"@parcel/watcher-win32-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz#7e9e02a26784d47503de1d10e8eab6cceb524243"
+  integrity sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==
+
+"@parcel/watcher-win32-ia32@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz#2d0f94fa59a873cdc584bf7f6b1dc628ddf976e6"
+  integrity sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==
+
+"@parcel/watcher-win32-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz#ae52693259664ba6f2228fa61d7ee44b64ea0947"
+  integrity sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==
+
+"@parcel/watcher@^2.4.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.5.1.tgz#342507a9cfaaf172479a882309def1e991fb1200"
+  integrity sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==
+  dependencies:
+    detect-libc "^1.0.3"
+    is-glob "^4.0.3"
+    micromatch "^4.0.5"
+    node-addon-api "^7.0.0"
+  optionalDependencies:
+    "@parcel/watcher-android-arm64" "2.5.1"
+    "@parcel/watcher-darwin-arm64" "2.5.1"
+    "@parcel/watcher-darwin-x64" "2.5.1"
+    "@parcel/watcher-freebsd-x64" "2.5.1"
+    "@parcel/watcher-linux-arm-glibc" "2.5.1"
+    "@parcel/watcher-linux-arm-musl" "2.5.1"
+    "@parcel/watcher-linux-arm64-glibc" "2.5.1"
+    "@parcel/watcher-linux-arm64-musl" "2.5.1"
+    "@parcel/watcher-linux-x64-glibc" "2.5.1"
+    "@parcel/watcher-linux-x64-musl" "2.5.1"
+    "@parcel/watcher-win32-arm64" "2.5.1"
+    "@parcel/watcher-win32-ia32" "2.5.1"
+    "@parcel/watcher-win32-x64" "2.5.1"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -3431,6 +3525,50 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.1.0.tgz#8b840305a6b48e8764803435ec0c716fa27d3802"
   integrity sha512-wO4Dk/rm8u7RNhOf95ZzcEmC9rYOncYgvq4z3duaJrCgjN8BxAnDVyndanfcJZ0O6XZzHz6Q0hTimxTg8Y9g/A==
 
+"@vitest/expect@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-1.6.1.tgz#b90c213f587514a99ac0bf84f88cff9042b0f14d"
+  integrity sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==
+  dependencies:
+    "@vitest/spy" "1.6.1"
+    "@vitest/utils" "1.6.1"
+    chai "^4.3.10"
+
+"@vitest/runner@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.6.1.tgz#10f5857c3e376218d58c2bfacfea1161e27e117f"
+  integrity sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==
+  dependencies:
+    "@vitest/utils" "1.6.1"
+    p-limit "^5.0.0"
+    pathe "^1.1.1"
+
+"@vitest/snapshot@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.6.1.tgz#90414451a634bb36cd539ccb29ae0d048a8c0479"
+  integrity sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==
+  dependencies:
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    pretty-format "^29.7.0"
+
+"@vitest/spy@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-1.6.1.tgz#33376be38a5ed1ecd829eb986edaecc3e798c95d"
+  integrity sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==
+  dependencies:
+    tinyspy "^2.2.0"
+
+"@vitest/utils@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-1.6.1.tgz#6d2f36cb6d866f2bbf59da854a324d6bf8040f17"
+  integrity sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==
+  dependencies:
+    diff-sequences "^29.6.3"
+    estree-walker "^3.0.3"
+    loupe "^2.3.7"
+    pretty-format "^29.7.0"
+
 "@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.11.5", "@webassemblyjs/ast@^1.12.1":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.14.1.tgz#a9f6a07f2b03c95c8d38c4536a1fdfb521ff55b6"
@@ -3600,7 +3738,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.1.1:
+acorn-walk@^8.1.1, acorn-walk@^8.3.2:
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
   integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
@@ -3802,6 +3940,11 @@ asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -4118,6 +4261,11 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 cacache@^15.2.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
@@ -4211,6 +4359,19 @@ caniuse-lite@^1.0.30001591, caniuse-lite@^1.0.30001733:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001733.tgz#918405ed6647a62840fb328832cf5a03f986974b"
   integrity sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==
 
+chai@^4.3.10:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
+  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.3"
+    deep-eql "^4.1.3"
+    get-func-name "^2.0.2"
+    loupe "^2.3.6"
+    pathval "^1.1.1"
+    type-detect "^4.1.0"
+
 chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -4233,6 +4394,13 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
+  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
+  dependencies:
+    get-func-name "^2.0.2"
 
 chokidar@3.5.3:
   version "3.5.3"
@@ -4263,6 +4431,13 @@ chokidar@3.5.3:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chokidar@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
+  dependencies:
+    readdirp "^4.0.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -4470,6 +4645,11 @@ concurrently@^8.2.2:
     supports-color "^8.1.1"
     tree-kill "^1.2.2"
     yargs "^17.7.2"
+
+confbox@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.8.tgz#820d73d3b3c82d9bd910652c5d4d599ef8ff8b06"
+  integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
 
 connect-history-api-fallback@^2.0.0:
   version "2.0.0"
@@ -4701,6 +4881,13 @@ dedent@^1.0.0, dedent@^1.6.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.6.0.tgz#79d52d6389b1ffa67d2bcef59ba51847a9d503b2"
   integrity sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==
 
+deep-eql@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
+  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -4768,6 +4955,11 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
 detect-libc@^2.0.0:
   version "2.0.4"
@@ -5209,6 +5401,13 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5258,6 +5457,21 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+execa@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
+  integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^8.0.1"
+    human-signals "^5.0.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^3.0.0"
 
 exit@^0.1.2:
   version "0.1.2"
@@ -5690,6 +5904,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.1, get-func-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
+  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
+
 get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
@@ -5730,6 +5949,11 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-stream@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
+  integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 github-from-package@0.0.0:
   version "0.0.0"
@@ -6030,6 +6254,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+human-signals@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
+  integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -6082,6 +6311,11 @@ immutable@^4.0.0:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
   integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
+
+immutable@^5.0.2:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.3.tgz#e6486694c8b76c37c063cca92399fa64098634d4"
+  integrity sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==
 
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"
@@ -6320,6 +6554,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-typed-array@^1.1.14:
   version "1.1.15"
@@ -6825,6 +7064,11 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
+  integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
+
 js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -7029,6 +7273,14 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+local-pkg@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.5.1.tgz#69658638d2a95287534d4c2fff757980100dbb6d"
+  integrity sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==
+  dependencies:
+    mlly "^1.7.3"
+    pkg-types "^1.2.1"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -7078,6 +7330,13 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+loupe@^2.3.6, loupe@^2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
+  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
+  dependencies:
+    get-func-name "^2.0.1"
+
 lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -7115,6 +7374,13 @@ magic-string@0.30.8:
   integrity sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
+
+magic-string@^0.30.5:
+  version "0.30.17"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
+  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
 
 make-dir@^2.1.0:
   version "2.1.0"
@@ -7225,7 +7491,7 @@ methods@^1.1.2, methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.8:
+micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -7264,6 +7530,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
 mimic-response@^3.1.0:
   version "3.1.0"
@@ -7420,6 +7691,16 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mlly@^1.7.3, mlly@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.7.4.tgz#3d7295ea2358ec7a271eaa5d000a0f84febe100f"
+  integrity sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==
+  dependencies:
+    acorn "^8.14.0"
+    pathe "^2.0.1"
+    pkg-types "^1.3.0"
+    ufo "^1.5.4"
 
 mrmime@2.0.0:
   version "2.0.0"
@@ -7737,6 +8018,13 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
+  dependencies:
+    path-key "^4.0.0"
+
 npmlog@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.2.tgz#c8166017a42f2dea92d6453168dd865186a70830"
@@ -7794,6 +8082,13 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
 
 open@8.4.2, open@^8.0.9:
   version "8.4.2"
@@ -7862,6 +8157,13 @@ p-limit@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
   integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
+p-limit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-5.0.0.tgz#6946d5b7140b649b7a33a027d89b4c625b3a5985"
+  integrity sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==
   dependencies:
     yocto-queue "^1.0.0"
 
@@ -8005,6 +8307,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
+
 path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -8037,6 +8344,21 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathe@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathe@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pg-cloudflare@^1.2.7:
   version "1.2.7"
@@ -8139,6 +8461,15 @@ pkg-dir@^7.0.0:
   integrity sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==
   dependencies:
     find-up "^6.3.0"
+
+pkg-types@^1.2.1, pkg-types@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
+  integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
+  dependencies:
+    confbox "^0.1.8"
+    mlly "^1.7.4"
+    pathe "^2.0.1"
 
 pluralize@8.0.0:
   version "8.0.0"
@@ -8474,6 +8805,11 @@ readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readdirp@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -8743,6 +9079,17 @@ sass@1.71.1:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
+sass@^1.69.0:
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.90.0.tgz#d6fc2be49c7c086ce86ea0b231a35bf9e33cb84b"
+  integrity sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==
+  dependencies:
+    chokidar "^4.0.0"
+    immutable "^5.0.2"
+    source-map-js ">=0.6.2 <2.0.0"
+  optionalDependencies:
+    "@parcel/watcher" "^2.4.1"
+
 sax@^1.2.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
@@ -8989,12 +9336,17 @@ side-channel@^1.0.4, side-channel@^1.0.6, side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -9231,6 +9583,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -9240,6 +9597,11 @@ statuses@2.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+std-env@^3.5.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
+  integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
 streamsearch@^1.1.0:
   version "1.1.0"
@@ -9331,6 +9693,11 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
+
 strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -9340,6 +9707,13 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
+strip-literal@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-2.1.1.tgz#26906e65f606d49f748454a08084e94190c2e5ad"
+  integrity sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==
+  dependencies:
+    js-tokens "^9.0.1"
 
 superagent@^8.1.2:
   version "8.1.2"
@@ -9508,6 +9882,21 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tinybench@^2.5.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinypool@^0.8.3:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.4.tgz#e217fe1270d941b39e98c625dcecebb1408c9aa8"
+  integrity sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==
+
+tinyspy@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
+  integrity sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9657,6 +10046,11 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
+type-detect@^4.0.0, type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
@@ -9733,6 +10127,11 @@ typescript@^5.3.3:
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+
+ufo@^1.5.4:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.1.tgz#ac2db1d54614d1b22c1d603e3aef44a85d8f146b"
+  integrity sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==
 
 uglify-js@^3.1.4:
   version "3.19.3"
@@ -9889,7 +10288,18 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vite@~5.4.17:
+vite-node@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.6.1.tgz#fff3ef309296ea03ceaa6ca4bb660922f5416c57"
+  integrity sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    vite "^5.0.0"
+
+vite@^5.0.0, vite@~5.4.17:
   version "5.4.19"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.19.tgz#20efd060410044b3ed555049418a5e7d1998f959"
   integrity sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==
@@ -9899,6 +10309,32 @@ vite@~5.4.17:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest@^1.3.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.6.1.tgz#b4a3097adf8f79ac18bc2e2e0024c534a7a78d2f"
+  integrity sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==
+  dependencies:
+    "@vitest/expect" "1.6.1"
+    "@vitest/runner" "1.6.1"
+    "@vitest/snapshot" "1.6.1"
+    "@vitest/spy" "1.6.1"
+    "@vitest/utils" "1.6.1"
+    acorn-walk "^8.3.2"
+    chai "^4.3.10"
+    debug "^4.3.4"
+    execa "^8.0.1"
+    local-pkg "^0.5.0"
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    std-env "^3.5.0"
+    strip-literal "^2.0.0"
+    tinybench "^2.5.1"
+    tinypool "^0.8.3"
+    vite "^5.0.0"
+    vite-node "1.6.1"
+    why-is-node-running "^2.2.2"
 
 wait-on@^7.0.1:
   version "7.2.0"
@@ -10145,6 +10581,14 @@ which@^4.0.0:
   dependencies:
     isexe "^3.1.1"
 
+why-is-node-running@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
+
 wide-align@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
@@ -10286,7 +10730,7 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
 
-zone.js@^0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.15.1.tgz#1e109adb75f80e9e004ee8e0d4a0a52e0a336481"
-  integrity sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==
+zone.js@^0.14.0:
+  version "0.14.10"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.14.10.tgz#23b8b29687c6bffece996e5ee5b854050e7775c8"
+  integrity sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==


### PR DESCRIPTION
## Summary
- make sidenav responsive with breakpoint observer and close on mobile navigation
- add fade animations for route transitions
- expose Swagger docs link in toolbar

## Testing
- `npm test -w @lcrt/frontend` *(fails: vitest not found)*
- `npm run lint -w @lcrt/frontend` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689a82acf100832c858bccd8db313036