### PR TITLE
feat: add next-up scheduling support

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -22,3 +22,12 @@ npm run migration:run -w @lcrt/backend
 - JSON: `http://localhost:3000/api-json`
 
 CORS is enabled by default.
+
+## Lists & Scheduling
+
+The API exposes a lightweight planning system for "Next-Up" problems.
+
+- `POST /lists/custom/:id/schedule` – create `PLANNED` scheduled items for a custom list.
+- `DELETE /lists/custom/:id/schedule` – cancel any `PLANNED` items for that list.
+- `GET /scheduled?type=NEXT_UP|REVISION|ALL` – view scheduled items.
+- `POST /scheduled/:id/done` – mark an item done and log completion details.

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { ProblemsModule } from './problems/problems.module';
 import { LeetcodeModule } from './leetcode/leetcode.module';
 import { UsersModule } from './users/users.module';
 import { ProblemListsModule } from './problem-lists/problem-lists.module';
+import { ScheduledItemsModule } from './scheduled-items/scheduled-items.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { ProblemListsModule } from './problem-lists/problem-lists.module';
     LeetcodeModule,
     UsersModule,
     ProblemListsModule,
+    ScheduledItemsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/packages/backend/src/completion-logs/completion-log.entity.ts
+++ b/packages/backend/src/completion-logs/completion-log.entity.ts
@@ -1,0 +1,37 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Problem } from '../problems/problem.entity';
+import { ScheduledItemType } from '../scheduled-items/scheduled-item.entity';
+
+@Entity()
+export class CompletionLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, { nullable: true })
+  user: User | null;
+
+  @ManyToOne(() => Problem)
+  problem: Problem;
+
+  @Column({ type: 'int', nullable: true })
+  ratedQuality: number | null;
+
+  @Column('text', { nullable: true })
+  notes: string | null;
+
+  @Column('text', { nullable: true })
+  solutionCode: string | null;
+
+  @Column({ type: 'int', nullable: true })
+  timeTakenMinutes: number | null;
+
+  @Column({ default: false })
+  referencesUsed: boolean;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  doneAt: Date;
+
+  @Column({ type: 'varchar' })
+  source: ScheduledItemType | 'ADHOC';
+}

--- a/packages/backend/src/leetcode/leetcode.service.spec.ts
+++ b/packages/backend/src/leetcode/leetcode.service.spec.ts
@@ -4,6 +4,10 @@ import { LeetcodeClient } from './leetcode.client';
 import { ProblemsService } from '../problems/problems.service';
 import { UserProblemsService } from '../user-problems/user-problems.service';
 import { LEETCODE_CONFIG } from './leetcode.config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ProblemList } from '../problem-lists/problem-list.entity';
+import { ProblemListItem } from '../problem-list-items/problem-list-item.entity';
+import { HttpService } from '@nestjs/axios';
 
 describe('LeetcodeService', () => {
   let service: LeetcodeService;
@@ -23,6 +27,9 @@ describe('LeetcodeService', () => {
         { provide: ProblemsService, useValue: problems },
         { provide: UserProblemsService, useValue: userProblems },
         { provide: LEETCODE_CONFIG, useValue: { username: 'me', pageSize: 20 } },
+        { provide: getRepositoryToken(ProblemList), useValue: {} },
+        { provide: getRepositoryToken(ProblemListItem), useValue: {} },
+        { provide: HttpService, useValue: { post: jest.fn() } },
       ],
     }).compile();
 

--- a/packages/backend/src/migrations/1754775901523-CreateScheduledItems.ts
+++ b/packages/backend/src/migrations/1754775901523-CreateScheduledItems.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateScheduledItems1754775901523 implements MigrationInterface {
+  name = 'CreateScheduledItems1754775901523';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "scheduled_item" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "type" character varying NOT NULL,
+        "userId" uuid,
+        "problemId" uuid NOT NULL,
+        "listId" uuid,
+        "dueAt" TIMESTAMP NOT NULL,
+        "status" character varying NOT NULL DEFAULT 'PLANNED',
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_scheduled_item_id" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "scheduled_item" ADD CONSTRAINT "FK_scheduled_item_user" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "scheduled_item" ADD CONSTRAINT "FK_scheduled_item_problem" FOREIGN KEY ("problemId") REFERENCES "problem"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "scheduled_item" ADD CONSTRAINT "FK_scheduled_item_list" FOREIGN KEY ("listId") REFERENCES "problem_list"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "scheduled_item" DROP CONSTRAINT "FK_scheduled_item_list"`);
+    await queryRunner.query(`ALTER TABLE "scheduled_item" DROP CONSTRAINT "FK_scheduled_item_problem"`);
+    await queryRunner.query(`ALTER TABLE "scheduled_item" DROP CONSTRAINT "FK_scheduled_item_user"`);
+    await queryRunner.query(`DROP TABLE "scheduled_item"`);
+  }
+}

--- a/packages/backend/src/migrations/1754775901524-CreateCompletionLogs.ts
+++ b/packages/backend/src/migrations/1754775901524-CreateCompletionLogs.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCompletionLogs1754775901524 implements MigrationInterface {
+  name = 'CreateCompletionLogs1754775901524';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "completion_log" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "userId" uuid,
+        "problemId" uuid NOT NULL,
+        "ratedQuality" integer,
+        "notes" text,
+        "solutionCode" text,
+        "timeTakenMinutes" integer,
+        "referencesUsed" boolean NOT NULL DEFAULT false,
+        "doneAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "source" character varying NOT NULL,
+        CONSTRAINT "PK_completion_log_id" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "completion_log" ADD CONSTRAINT "FK_completion_log_user" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "completion_log" ADD CONSTRAINT "FK_completion_log_problem" FOREIGN KEY ("problemId") REFERENCES "problem"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "completion_log" DROP CONSTRAINT "FK_completion_log_problem"`);
+    await queryRunner.query(`ALTER TABLE "completion_log" DROP CONSTRAINT "FK_completion_log_user"`);
+    await queryRunner.query(`DROP TABLE "completion_log"`);
+  }
+}

--- a/packages/backend/src/problem-lists/custom-lists.controller.ts
+++ b/packages/backend/src/problem-lists/custom-lists.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ProblemListsService } from './problem-lists.service';
+
+@Controller('lists/custom')
+export class CustomListsController {
+  constructor(private readonly service: ProblemListsService) {}
+
+  @Post()
+  create(@Body('name') name: string) {
+    return this.service.create(name);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findCustomLists();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOneWithItems(id);
+  }
+
+  @Post(':id/items')
+  addItems(@Param('id') id: string, @Body('problemIds') problemIds: string[]) {
+    return this.service.addProblems(id, problemIds);
+  }
+}

--- a/packages/backend/src/problem-lists/problem-lists.module.ts
+++ b/packages/backend/src/problem-lists/problem-lists.module.ts
@@ -4,15 +4,17 @@ import { ProblemList } from './problem-list.entity';
 import { ProblemListItem } from '../problem-list-items/problem-list-item.entity';
 import { ProblemListsService } from './problem-lists.service';
 import { ProblemListsController } from './problem-lists.controller';
+import { CustomListsController } from './custom-lists.controller';
 import { UserProblemsModule } from '../user-problems/user-problems.module';
+import { Problem } from '../problems/problem.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ProblemList, ProblemListItem]),
+    TypeOrmModule.forFeature([ProblemList, ProblemListItem, Problem]),
     UserProblemsModule,
   ],
   providers: [ProblemListsService],
-  controllers: [ProblemListsController],
+  controllers: [ProblemListsController, CustomListsController],
   exports: [ProblemListsService],
 })
 export class ProblemListsModule {}

--- a/packages/backend/src/scheduled-items/custom-list-scheduling.controller.ts
+++ b/packages/backend/src/scheduled-items/custom-list-scheduling.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
+import { ScheduledItemsService } from './scheduled-items.service';
+import { ScheduleListDto } from './dto/schedule-list.dto';
+
+@Controller('lists/custom')
+export class CustomListSchedulingController {
+  constructor(private readonly service: ScheduledItemsService) {}
+
+  @Post(':id/schedule')
+  schedule(@Param('id') id: string, @Body() dto: ScheduleListDto) {
+    return this.service.scheduleList(id, dto);
+  }
+
+  @Delete(':id/schedule')
+  unschedule(@Param('id') id: string) {
+    return this.service.unscheduleList(id);
+  }
+}

--- a/packages/backend/src/scheduled-items/dto/get-scheduled.query.ts
+++ b/packages/backend/src/scheduled-items/dto/get-scheduled.query.ts
@@ -1,0 +1,38 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsISO8601, IsInt, Min, Max } from 'class-validator';
+import { ScheduledItemType } from '../scheduled-item.entity';
+
+export class GetScheduledQueryDto {
+  @ApiPropertyOptional({ enum: ['ALL', 'NEXT_UP', 'REVISION'], example: 'ALL' })
+  @IsOptional()
+  @IsEnum(['ALL', 'NEXT_UP', 'REVISION'])
+  type?: 'ALL' | ScheduledItemType;
+
+  @ApiPropertyOptional({ enum: ['PLANNED', 'DONE', 'CANCELLED'], example: 'PLANNED' })
+  @IsOptional()
+  @IsEnum(['PLANNED', 'DONE', 'CANCELLED'])
+  status?: 'PLANNED' | 'DONE' | 'CANCELLED';
+
+  @ApiPropertyOptional({ description: 'Start date (inclusive) in ISO-8601 (yyyy-mm-dd or full ISO)' })
+  @IsOptional()
+  @IsISO8601()
+  from?: string;
+
+  @ApiPropertyOptional({ description: 'End date (inclusive) in ISO-8601' })
+  @IsOptional()
+  @IsISO8601()
+  to?: string;
+
+  @ApiPropertyOptional({ description: 'Page (1-based)', example: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Page size', example: 25 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number;
+}

--- a/packages/backend/src/scheduled-items/dto/mark-done.dto.ts
+++ b/packages/backend/src/scheduled-items/dto/mark-done.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class MarkDoneDto {
+  @ApiProperty({ required: false, minimum: 0, maximum: 5 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(5)
+  ratedQuality?: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  solutionCode?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  timeTakenMinutes?: number;
+
+  @ApiProperty({ required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  referencesUsed?: boolean;
+}

--- a/packages/backend/src/scheduled-items/dto/schedule-list.dto.ts
+++ b/packages/backend/src/scheduled-items/dto/schedule-list.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsISO8601, IsOptional } from 'class-validator';
+
+export enum ScheduleSpacing {
+  DAILY = 'DAILY',
+  ALT_DAYS = 'ALT_DAYS',
+  WEEKLY = 'WEEKLY',
+  ALL_TODAY = 'ALL_TODAY',
+}
+
+export class ScheduleListDto {
+  @ApiProperty({ required: false, type: String })
+  @IsOptional()
+  @IsISO8601()
+  startDate?: string;
+
+  @ApiProperty({ required: false, enum: ScheduleSpacing })
+  @IsOptional()
+  @IsEnum(ScheduleSpacing)
+  spacing?: ScheduleSpacing;
+}

--- a/packages/backend/src/scheduled-items/scheduled-item.entity.ts
+++ b/packages/backend/src/scheduled-items/scheduled-item.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { Problem } from '../problems/problem.entity';
+import { ProblemList } from '../problem-lists/problem-list.entity';
+
+export type ScheduledItemType = 'NEXT_UP' | 'REVISION';
+export type ScheduledItemStatus = 'PLANNED' | 'DONE' | 'CANCELLED';
+
+@Entity()
+export class ScheduledItem {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  type: ScheduledItemType;
+
+  @ManyToOne(() => User, { nullable: true })
+  user: User | null;
+
+  @ManyToOne(() => Problem, { eager: true })
+  problem: Problem;
+
+  @ManyToOne(() => ProblemList, { nullable: true })
+  list: ProblemList | null;
+
+  @Column({ type: 'timestamp' })
+  dueAt: Date;
+
+  @Column({ type: 'varchar', default: 'PLANNED' })
+  status: ScheduledItemStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/packages/backend/src/scheduled-items/scheduled-items.controller.ts
+++ b/packages/backend/src/scheduled-items/scheduled-items.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ScheduledItemsService } from './scheduled-items.service';
+import { MarkDoneDto } from './dto/mark-done.dto';
+
+@Controller('scheduled')
+export class ScheduledItemsController {
+  constructor(private readonly service: ScheduledItemsService) {}
+
+  @Get()
+  findAll(@Query('type') type?: string) {
+    return this.service.findAll(type);
+  }
+
+  @Post(':id/done')
+  markDone(@Param('id') id: string, @Body() dto: MarkDoneDto) {
+    return this.service.markDone(id, dto);
+  }
+}

--- a/packages/backend/src/scheduled-items/scheduled-items.controller.ts
+++ b/packages/backend/src/scheduled-items/scheduled-items.controller.ts
@@ -1,17 +1,29 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { ScheduledItemsService } from './scheduled-items.service';
 import { MarkDoneDto } from './dto/mark-done.dto';
+import { GetScheduledQueryDto } from './dto/get-scheduled.query';
+import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
 
 @Controller('scheduled')
 export class ScheduledItemsController {
   constructor(private readonly service: ScheduledItemsService) {}
 
   @Get()
-  findAll(@Query('type') type?: string) {
-    return this.service.findAll(type);
+  @ApiOkResponse({ description: 'List scheduled items' })
+  findAll(@Query() q: GetScheduledQueryDto) {
+    const from = q.from ? new Date(q.from) : undefined;
+    const to = q.to ? new Date(q.to) : undefined;
+    return this.service.findAll(q.type, q.status ?? 'PLANNED', from, to, q.page ?? 1, q.pageSize ?? 25);
+  }
+
+  @Post('problem/:id')
+  @ApiCreatedResponse({ description: 'Scheduled problem' })
+  scheduleProblem(@Param('id') id: string) {
+    return this.service.scheduleProblem(id);
   }
 
   @Post(':id/done')
+  @ApiOkResponse({ description: 'Marked as done and logged completion' })
   markDone(@Param('id') id: string, @Body() dto: MarkDoneDto) {
     return this.service.markDone(id, dto);
   }

--- a/packages/backend/src/scheduled-items/scheduled-items.module.ts
+++ b/packages/backend/src/scheduled-items/scheduled-items.module.ts
@@ -6,10 +6,11 @@ import { ScheduledItemsController } from './scheduled-items.controller';
 import { CustomListSchedulingController } from './custom-list-scheduling.controller';
 import { ProblemListItem } from '../problem-list-items/problem-list-item.entity';
 import { CompletionLog } from '../completion-logs/completion-log.entity';
+import { Problem } from '../problems/problem.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ScheduledItem, ProblemListItem, CompletionLog]),
+    TypeOrmModule.forFeature([ScheduledItem, ProblemListItem, CompletionLog, Problem]),
   ],
   controllers: [ScheduledItemsController, CustomListSchedulingController],
   providers: [ScheduledItemsService],

--- a/packages/backend/src/scheduled-items/scheduled-items.module.ts
+++ b/packages/backend/src/scheduled-items/scheduled-items.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduledItem } from './scheduled-item.entity';
+import { ScheduledItemsService } from './scheduled-items.service';
+import { ScheduledItemsController } from './scheduled-items.controller';
+import { CustomListSchedulingController } from './custom-list-scheduling.controller';
+import { ProblemListItem } from '../problem-list-items/problem-list-item.entity';
+import { CompletionLog } from '../completion-logs/completion-log.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ScheduledItem, ProblemListItem, CompletionLog]),
+  ],
+  controllers: [ScheduledItemsController, CustomListSchedulingController],
+  providers: [ScheduledItemsService],
+  exports: [ScheduledItemsService],
+})
+export class ScheduledItemsModule {}

--- a/packages/backend/src/scheduled-items/scheduled-items.service.ts
+++ b/packages/backend/src/scheduled-items/scheduled-items.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ScheduledItem } from './scheduled-item.entity';
+import { ProblemListItem } from '../problem-list-items/problem-list-item.entity';
+import { ScheduleListDto, ScheduleSpacing } from './dto/schedule-list.dto';
+import { MarkDoneDto } from './dto/mark-done.dto';
+import { CompletionLog } from '../completion-logs/completion-log.entity';
+
+@Injectable()
+export class ScheduledItemsService {
+  constructor(
+    @InjectRepository(ScheduledItem)
+    private readonly repo: Repository<ScheduledItem>,
+    @InjectRepository(ProblemListItem)
+    private readonly listItemRepo: Repository<ProblemListItem>,
+    @InjectRepository(CompletionLog)
+    private readonly logRepo: Repository<CompletionLog>,
+  ) {}
+
+  async scheduleList(listId: string, dto: ScheduleListDto) {
+    const items = await this.listItemRepo.find({
+      where: { list: { id: listId } },
+      relations: ['problem', 'list'],
+      order: { order: 'ASC' },
+    });
+    if (items.length === 0) {
+      return [];
+    }
+    const start = dto.startDate ? new Date(dto.startDate) : new Date();
+    const spacing: ScheduleSpacing = dto.spacing || ScheduleSpacing.DAILY;
+    const increment = (idx: number) => {
+      switch (spacing) {
+        case ScheduleSpacing.ALL_TODAY:
+          return 0;
+        case ScheduleSpacing.ALT_DAYS:
+          return idx * 2;
+        case ScheduleSpacing.WEEKLY:
+          return idx * 7;
+        default:
+          return idx;
+      }
+    };
+    const scheduled: ScheduledItem[] = [];
+    items.forEach((item, idx) => {
+      const dueAt = new Date(start);
+      const addDays = increment(idx);
+      if (addDays) {
+        dueAt.setDate(dueAt.getDate() + addDays);
+      }
+      const entity = this.repo.create({
+        type: 'NEXT_UP',
+        problem: item.problem,
+        list: item.list,
+        dueAt,
+        status: 'PLANNED',
+      });
+      scheduled.push(entity);
+    });
+    return this.repo.save(scheduled);
+  }
+
+  async unscheduleList(listId: string) {
+    await this.repo.update(
+      { list: { id: listId }, status: 'PLANNED' },
+      { status: 'CANCELLED' },
+    );
+    return { success: true };
+  }
+
+  findAll(type?: string) {
+    const where = type && type !== 'ALL' ? { type } : {};
+    return this.repo.find({ where, order: { dueAt: 'ASC' } });
+  }
+
+  async markDone(id: string, dto: MarkDoneDto) {
+    const item = await this.repo.findOne({ where: { id }, relations: ['problem', 'user'] });
+    if (!item) {
+      throw new NotFoundException('Scheduled item not found');
+    }
+    item.status = 'DONE';
+    await this.repo.save(item);
+    const log = this.logRepo.create({
+      user: item.user,
+      problem: item.problem,
+      ratedQuality: dto.ratedQuality ?? null,
+      notes: dto.notes ?? null,
+      solutionCode: dto.solutionCode ?? null,
+      timeTakenMinutes: dto.timeTakenMinutes ?? null,
+      referencesUsed: dto.referencesUsed ?? false,
+      source: item.type,
+    });
+    await this.logRepo.save(log);
+    return item;
+  }
+}

--- a/packages/backend/src/scheduled-items/scheduled-items.service.ts
+++ b/packages/backend/src/scheduled-items/scheduled-items.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { ScheduledItem } from './scheduled-item.entity';
+import { Repository, FindOptionsWhere } from 'typeorm';
+import { ScheduledItem, ScheduledItemType } from './scheduled-item.entity';
 import { ProblemListItem } from '../problem-list-items/problem-list-item.entity';
 import { ScheduleListDto, ScheduleSpacing } from './dto/schedule-list.dto';
 import { MarkDoneDto } from './dto/mark-done.dto';
@@ -68,8 +68,9 @@ export class ScheduledItemsService {
     return { success: true };
   }
 
-  findAll(type?: string) {
-    const where = type && type !== 'ALL' ? { type } : {};
+  findAll(type?: ScheduledItemType | 'ALL') {
+    const where: FindOptionsWhere<ScheduledItem> | undefined =
+      type && type !== 'ALL' ? { type } : undefined;
     return this.repo.find({ where, order: { dueAt: 'ASC' } });
   }
 

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -21,6 +21,8 @@ Routes are defined in `src/app/app.routes.ts`.
 - `/reviews` spaced-repetition reviews
 - `/problems` problem browser
 - `/lists` saved lists
+- `/lists/custom` manage custom lists and schedule them for upcoming practice
+- `/scheduled` view items planned for Next-Up or due for revision
 - `/sync` trigger LeetCode sync
 
 ### Theme Toggle

--- a/packages/frontend/src/app/app.routes.ts
+++ b/packages/frontend/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { ProblemDetailPage } from './features/problem-detail/problem-detail.page
 import { ListsPage } from './features/lists/lists.page';
 import { ListDetailPage } from './features/list-detail/list-detail.page';
 import { SyncPage } from './features/sync/sync.page';
+import { ScheduledPage } from './features/scheduled/scheduled.page';
 
 export const appRoutes: Routes = [
   { path: '', component: DashboardPage },
@@ -14,6 +15,7 @@ export const appRoutes: Routes = [
   { path: 'problems/:slug', component: ProblemDetailPage },
   { path: 'lists', component: ListsPage },
   { path: 'lists/:id', component: ListDetailPage },
+  { path: 'scheduled', component: ScheduledPage },
   { path: 'sync', component: SyncPage },
   { path: '**', redirectTo: '' }
 ];

--- a/packages/frontend/src/app/core/lists.facade.ts
+++ b/packages/frontend/src/app/core/lists.facade.ts
@@ -13,7 +13,7 @@ export class ListsFacade {
 
   getLists(): Observable<UiList[]> {
     this.loading.set(true);
-    return this.http.get<any[]>('/api/lists').pipe(
+    return this.http.get<any[]>('/api/lists/custom').pipe(
       map(arr => arr.map(apiListToUi)),
       catchError(err => {
         this.toast.error('Failed to load lists');
@@ -25,7 +25,7 @@ export class ListsFacade {
 
   getList(id: string): Observable<UiList> {
     this.loading.set(true);
-    return this.http.get<any>(`/api/lists/${id}`).pipe(
+    return this.http.get<any>(`/api/lists/custom/${id}`).pipe(
       map(apiListToUi),
       catchError(err => {
         this.toast.error('Failed to load list');
@@ -40,6 +40,34 @@ export class ListsFacade {
       map(apiListToUi),
       catchError(err => {
         this.toast.error('Failed to import list');
+        return throwError(() => err);
+      })
+    );
+  }
+
+  createList(name: string): Observable<UiList> {
+    return this.http.post<any>('/api/lists/custom', { name }).pipe(
+      map(apiListToUi),
+      catchError(err => {
+        this.toast.error('Failed to create list');
+        return throwError(() => err);
+      })
+    );
+  }
+
+  addProblems(listId: string, problemIds: string[]): Observable<any> {
+    return this.http.post(`/api/lists/custom/${listId}/items`, { problemIds }).pipe(
+      catchError(err => {
+        this.toast.error('Failed to add problems');
+        return throwError(() => err);
+      })
+    );
+  }
+
+  scheduleList(listId: string): Observable<any> {
+    return this.http.post(`/api/lists/custom/${listId}/schedule`, {}).pipe(
+      catchError(err => {
+        this.toast.error('Failed to schedule list');
         return throwError(() => err);
       })
     );

--- a/packages/frontend/src/app/core/mappers/scheduled-item.mapper.spec.ts
+++ b/packages/frontend/src/app/core/mappers/scheduled-item.mapper.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { apiScheduledItemToUi } from './scheduled-item.mapper';
+import { Difficulty } from '../models';
+
+describe('apiScheduledItemToUi', () => {
+  it('maps scheduled item correctly', () => {
+    const due = new Date().toISOString();
+    const ui = apiScheduledItemToUi({
+      id: 's1',
+      type: 'NEXT_UP',
+      problem: { id: 'p1', slug: 'two-sum', title: 'Two Sum', difficulty: 'Easy', tags: [] },
+      dueAt: due,
+      status: 'PLANNED'
+    });
+    expect(ui.problem.difficulty).toBe(Difficulty.Easy);
+    expect(ui.dueAt).toBeInstanceOf(Date);
+    expect(ui.type).toBe('NEXT_UP');
+  });
+});

--- a/packages/frontend/src/app/core/mappers/scheduled-item.mapper.ts
+++ b/packages/frontend/src/app/core/mappers/scheduled-item.mapper.ts
@@ -1,0 +1,12 @@
+import { UiScheduledItem } from '../models';
+import { apiProblemToUi } from './problem.mapper';
+
+export function apiScheduledItemToUi(si: any): UiScheduledItem {
+  return {
+    id: si.id,
+    type: si.type,
+    problem: apiProblemToUi(si.problem),
+    dueAt: new Date(si.dueAt),
+    status: si.status,
+  };
+}

--- a/packages/frontend/src/app/core/models/index.ts
+++ b/packages/frontend/src/app/core/models/index.ts
@@ -3,3 +3,4 @@ export * from './ui-problem';
 export * from './ui-review';
 export * from './ui-list';
 export * from './sync-result';
+export * from './ui-scheduled-item';

--- a/packages/frontend/src/app/core/models/ui-scheduled-item.ts
+++ b/packages/frontend/src/app/core/models/ui-scheduled-item.ts
@@ -1,0 +1,9 @@
+import { UiProblem } from './ui-problem';
+
+export interface UiScheduledItem {
+  id: string;
+  type: 'NEXT_UP' | 'REVISION';
+  problem: UiProblem;
+  dueAt: Date;
+  status: 'PLANNED' | 'DONE' | 'CANCELLED';
+}

--- a/packages/frontend/src/app/core/scheduled.facade.ts
+++ b/packages/frontend/src/app/core/scheduled.facade.ts
@@ -1,0 +1,25 @@
+import { Injectable, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, catchError, finalize, map, throwError } from 'rxjs';
+import { UiScheduledItem } from './models';
+import { apiScheduledItemToUi } from './mappers/scheduled-item.mapper';
+import { ToastService } from './toast.service';
+
+@Injectable({ providedIn: 'root' })
+export class ScheduledFacade {
+  loading = signal(false);
+
+  constructor(private http: HttpClient, private toast: ToastService) {}
+
+  getScheduled(): Observable<UiScheduledItem[]> {
+    this.loading.set(true);
+    return this.http.get<any[]>('/api/scheduled').pipe(
+      map(arr => arr.map(apiScheduledItemToUi)),
+      catchError(err => {
+        this.toast.error('Failed to load scheduled items');
+        return throwError(() => err);
+      }),
+      finalize(() => this.loading.set(false))
+    );
+  }
+}

--- a/packages/frontend/src/app/core/scheduled.facade.ts
+++ b/packages/frontend/src/app/core/scheduled.facade.ts
@@ -13,13 +13,22 @@ export class ScheduledFacade {
 
   getScheduled(): Observable<UiScheduledItem[]> {
     this.loading.set(true);
-    return this.http.get<any[]>('/api/scheduled').pipe(
-      map(arr => arr.map(apiScheduledItemToUi)),
+    return this.http.get<any>('/api/scheduled').pipe(
+      map(res => (res.items ?? []).map(apiScheduledItemToUi)),
       catchError(err => {
         this.toast.error('Failed to load scheduled items');
         return throwError(() => err);
       }),
       finalize(() => this.loading.set(false))
+    );
+  }
+
+  scheduleProblem(problemId: string): Observable<any> {
+    return this.http.post(`/api/scheduled/problem/${problemId}`, {}).pipe(
+      catchError(err => {
+        this.toast.error('Failed to schedule problem');
+        return throwError(() => err);
+      })
     );
   }
 }

--- a/packages/frontend/src/app/features/dashboard/dashboard.page.html
+++ b/packages/frontend/src/app/features/dashboard/dashboard.page.html
@@ -9,3 +9,21 @@
     </mat-card-header>
   </mat-card>
 </section>
+
+<section class="due" *ngIf="dueToday.length">
+  <h2>Due Today</h2>
+  <mat-list>
+    <mat-list-item *ngFor="let item of dueToday; trackBy: trackByItem">
+      {{ item.problem.title }}
+    </mat-list-item>
+  </mat-list>
+</section>
+
+<section class="upcoming" *ngIf="upcoming.length">
+  <h2>Upcoming</h2>
+  <mat-list>
+    <mat-list-item *ngFor="let item of upcoming; trackBy: trackByItem">
+      {{ item.problem.title }} - {{ item.dueAt | date:'shortDate' }}
+    </mat-list-item>
+  </mat-list>
+</section>

--- a/packages/frontend/src/app/features/list-detail/list-detail.page.html
+++ b/packages/frontend/src/app/features/list-detail/list-detail.page.html
@@ -1,5 +1,13 @@
 <ng-container *ngIf="list$ | async as list; else loading">
   <h2>{{ list.name }}</h2>
+  <button mat-raised-button color="primary" (click)="scheduleList(list.id)">Schedule List</button>
+  <div class="add-problem">
+    <mat-form-field appearance="outline">
+      <mat-label>Problem ID</mat-label>
+      <input matInput [(ngModel)]="newProblemId" />
+    </mat-form-field>
+    <button mat-stroked-button color="primary" (click)="addProblem(list.id)">Add Problem</button>
+  </div>
 
   <table
     mat-table

--- a/packages/frontend/src/app/features/list-detail/list-detail.page.ts
+++ b/packages/frontend/src/app/features/list-detail/list-detail.page.ts
@@ -1,6 +1,9 @@
 import { Component, inject } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
-import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { AsyncPipe, NgFor, NgIf, FormsModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { DifficultyPillComponent } from '../../shared/ui/difficulty-pill/difficulty-pill.component';
 import { TagChipComponent } from '../../shared/ui/tag-chip/tag-chip.component';
 import { ListsFacade } from '../../core/lists.facade';
@@ -20,7 +23,8 @@ type Row = {
   standalone: true,
   imports: [
     MatTableModule,
-    NgFor, NgIf, AsyncPipe,
+    NgFor, NgIf, AsyncPipe, FormsModule,
+    MatButtonModule, MatFormFieldModule, MatInputModule,
     DifficultyPillComponent,
     TagChipComponent,
   ],
@@ -32,6 +36,7 @@ export class ListDetailPage {
   private route = inject(ActivatedRoute);
 
   displayedColumns = ['title', 'tags', 'difficulty'];
+  newProblemId = '';
 
   // Load the list reactively when the route param changes
   list$: Observable<UiList> = this.route.paramMap.pipe(
@@ -59,4 +64,16 @@ export class ListDetailPage {
 
   trackById = (_: number, r: Row) => r.id;
   trackByTag = (_: number, t: string) => t;
+
+  scheduleList(id: string) {
+    this.facade.scheduleList(id).subscribe();
+  }
+
+  addProblem(id: string) {
+    if (!this.newProblemId) return;
+    this.facade.addProblems(id, [this.newProblemId]).subscribe(() => {
+      this.newProblemId = '';
+      this.list$ = this.facade.getList(id);
+    });
+  }
 }

--- a/packages/frontend/src/app/features/list-detail/list-detail.page.ts
+++ b/packages/frontend/src/app/features/list-detail/list-detail.page.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
-import { AsyncPipe, NgFor, NgIf, FormsModule } from '@angular/common';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';

--- a/packages/frontend/src/app/features/lists/lists.page.html
+++ b/packages/frontend/src/app/features/lists/lists.page.html
@@ -86,7 +86,7 @@
 <!-- New list dialog -->
 <ng-template #newListDialog>
   <h1 mat-dialog-title>New List</h1>
-  <form #f="ngForm" (ngSubmit)="" >
+  <form #f="ngForm">
     <div mat-dialog-content>
       <mat-form-field appearance="outline" class="w-100">
         <mat-label>Name</mat-label>

--- a/packages/frontend/src/app/features/lists/lists.page.html
+++ b/packages/frontend/src/app/features/lists/lists.page.html
@@ -2,7 +2,10 @@
 <mat-progress-bar *ngIf="isBusy" mode="indeterminate"></mat-progress-bar>
 
 <div class="actions">
-  <button mat-raised-button color="primary" (click)="openImportDialog()">
+  <button mat-raised-button color="primary" (click)="openNewListDialog()">
+    New List
+  </button>
+  <button mat-stroked-button color="primary" (click)="openImportDialog()">
     Import List
   </button>
 </div>
@@ -76,6 +79,23 @@
       >
         Import
       </button>
+    </div>
+  </form>
+</ng-template>
+
+<!-- New list dialog -->
+<ng-template #newListDialog>
+  <h1 mat-dialog-title>New List</h1>
+  <form #f="ngForm" (ngSubmit)="" >
+    <div mat-dialog-content>
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label>Name</mat-label>
+        <input matInput name="name" [(ngModel)]="newListName" required />
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close type="button">Cancel</button>
+      <button mat-raised-button color="primary" [mat-dialog-close]="newListName" type="submit">Create</button>
     </div>
   </form>
 </ng-template>

--- a/packages/frontend/src/app/features/lists/lists.page.ts
+++ b/packages/frontend/src/app/features/lists/lists.page.ts
@@ -9,8 +9,9 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
-import { ListsFacade } from '../../core/lists.facade';
+  import { ListsFacade } from '../../core/lists.facade';
 import { UiList } from '../../core/models';
 import { Observable } from 'rxjs';
 
@@ -33,6 +34,7 @@ import { Observable } from 'rxjs';
     NgFor,
     NgIf,
     AsyncPipe,
+    FormsModule,
   ],
   templateUrl: './lists.page.html',
   styleUrls: ['./lists.page.scss'],
@@ -40,12 +42,14 @@ import { Observable } from 'rxjs';
 export class ListsPage implements OnInit {
   lists$!: Observable<UiList[]>;
   importUrl = '';
+  newListName = '';
   isBusy = false;
 
   /** Accept http(s)://… OR a slug like "folder/name" or "my-list" */
   readonly importPattern = '^(https?://\\S+|[A-Za-z0-9](?:[A-Za-z0-9\\-/]*))$';
 
   @ViewChild('importDialog') importDialog!: TemplateRef<any>;
+  @ViewChild('newListDialog') newListDialog!: TemplateRef<any>;
 
   private dialog = inject(MatDialog);
   private facade = inject(ListsFacade);
@@ -66,6 +70,18 @@ export class ListsPage implements OnInit {
       .subscribe((url: string | null | undefined) => {
         if (url && this.isValidImport(url)) {
           this.doImport(url);
+        }
+      });
+  }
+
+  openNewListDialog() {
+    this.newListName = '';
+    this.dialog
+      .open(this.newListDialog, { width: '360px' })
+      .afterClosed()
+      .subscribe((name: string | null | undefined) => {
+        if (name) {
+          this.facade.createList(name).subscribe(() => this.load());
         }
       });
   }

--- a/packages/frontend/src/app/features/problem-detail/problem-detail.page.html
+++ b/packages/frontend/src/app/features/problem-detail/problem-detail.page.html
@@ -12,6 +12,7 @@
 
     <mat-card-actions>
       <button mat-raised-button color="primary" (click)="rate(problem)">Rate Recall</button>
+      <button mat-stroked-button color="primary" (click)="schedule(problem)">Schedule</button>
     </mat-card-actions>
 
     <mat-tab-group>

--- a/packages/frontend/src/app/features/problem-detail/problem-detail.page.ts
+++ b/packages/frontend/src/app/features/problem-detail/problem-detail.page.ts
@@ -17,6 +17,7 @@ import { ReviewsFacade } from '../../core/reviews.facade';
 import { UiProblem } from '../../core/models';
 import { Observable, map, switchMap, filter, of } from 'rxjs';
 import { RateDialogComponent } from '../../shared/ui/rate-dialog/rate-dialog.component';
+import { ScheduledFacade } from '../../core/scheduled.facade';
 
 @Component({
   selector: 'app-problem-detail-page',
@@ -41,6 +42,7 @@ export class ProblemDetailPage implements OnInit {
   private reviews = inject(ReviewsFacade);
   private dialog = inject(MatDialog);
   private snack = inject(MatSnackBar);
+  private scheduled = inject(ScheduledFacade);
 
   problem$!: Observable<UiProblem>;
 
@@ -97,5 +99,12 @@ export class ProblemDetailPage implements OnInit {
         next: () => this.snack.open('Recall rated', undefined, { duration: 1500 }),
         error: () => this.snack.open('Failed to submit rating', 'Dismiss', { duration: 2500 })
       });
+  }
+
+  schedule(problem: UiProblem) {
+    this.scheduled.scheduleProblem(problem.id).subscribe({
+      next: () => this.snack.open('Scheduled', undefined, { duration: 1500 }),
+      error: () => this.snack.open('Failed to schedule', 'Dismiss', { duration: 2500 }),
+    });
   }
 }

--- a/packages/frontend/src/app/features/scheduled/scheduled.page.html
+++ b/packages/frontend/src/app/features/scheduled/scheduled.page.html
@@ -1,0 +1,6 @@
+<mat-list>
+  <mat-list-item *ngFor="let item of items$ | async; trackBy: trackById">
+    <div matListItemTitle>{{ item.problem.title }}</div>
+    <div matListItemLine>{{ item.dueAt | date:'mediumDate' }} - {{ item.type }}</div>
+  </mat-list-item>
+</mat-list>

--- a/packages/frontend/src/app/features/scheduled/scheduled.page.ts
+++ b/packages/frontend/src/app/features/scheduled/scheduled.page.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { MatListModule } from '@angular/material/list';
+import { AsyncPipe, NgFor } from '@angular/common';
+import { ScheduledFacade } from '../../core/scheduled.facade';
+import { UiScheduledItem } from '../../core/models';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-scheduled-page',
+  standalone: true,
+  imports: [MatListModule, AsyncPipe, NgFor],
+  templateUrl: './scheduled.page.html',
+  styleUrls: ['./scheduled.page.scss'],
+})
+export class ScheduledPage implements OnInit {
+  items$!: Observable<UiScheduledItem[]>;
+  private facade = inject(ScheduledFacade);
+
+  ngOnInit() {
+    this.items$ = this.facade.getScheduled();
+  }
+
+  trackById = (_: number, item: UiScheduledItem) => item.id;
+}

--- a/packages/frontend/src/app/shared/ui/app-sidenav.component.html
+++ b/packages/frontend/src/app/shared/ui/app-sidenav.component.html
@@ -21,8 +21,13 @@
   </a>
 
   <a mat-list-item routerLink="/lists" routerLinkActive="active" (click)="navigate.emit()">
-    <mat-icon matListIcon aria-hidden="true">playlist_add_check</mat-icon>
-    <span class="label">Lists</span>
+    <mat-icon matListIcon aria-hidden="true">playlist_add</mat-icon>
+    <span class="label">Custom Lists</span>
+  </a>
+
+  <a mat-list-item routerLink="/scheduled" routerLinkActive="active" (click)="navigate.emit()">
+    <mat-icon matListIcon aria-hidden="true">event</mat-icon>
+    <span class="label">Scheduled</span>
   </a>
 
   <a mat-list-item routerLink="/sync" routerLinkActive="active" (click)="navigate.emit()">


### PR DESCRIPTION
## Summary
- add ScheduledItem and CompletionLog entities
- create endpoints to schedule/unschedule lists and mark items done
- document new scheduling flow in backend and frontend READMEs

## Testing
- `npm test -w @lcrt/backend`
- `npm test -w @lcrt/frontend` *(fails: Cannot find dependency 'jsdom')*
- `npm install jsdom -w @lcrt/frontend` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a9df522f0832cb37dd4c745eeafa6